### PR TITLE
[DB] 엔티티 패키지 구조 생성 및 핵심 도메인 엔티티 추가

### DIFF
--- a/src/main/java/io/github/petty/tour/entity/Content.java
+++ b/src/main/java/io/github/petty/tour/entity/Content.java
@@ -1,0 +1,104 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+public class Content {
+    @Id
+    @Column(name = "contentid", nullable = false)
+    private Long contentId;
+    @Column(name = "contenttypeid", nullable = false)
+    private Integer contentTypeId;
+    @Column(name = "title", nullable = false)
+    private String title;
+    @Column(name = "addr1")
+    private String addr1;
+    @Column(name = "addr2", length = 100)
+    private String addr2;
+
+    @Column(name = "areacode")
+    private Integer areaCode;
+
+    @Column(name = "sigungucode")
+    private Integer sigunguCode;
+
+    @Column(name = "cat1", nullable = false, length = 10)
+    private String cat1;
+
+    @Column(name = "cat2", length = 10)
+    private String cat2;
+
+    @Column(name = "cat3", length = 10)
+    private String cat3;
+
+    @Column(name = "createdtime", nullable = false)
+    private Instant createdTime;
+
+    @Column(name = "modifiedtime", nullable = false)
+    private Instant modifiedTime;
+
+    @Column(name = "firstimage", length = 2048)
+    private String firstImage;
+
+    @Column(name = "firstimage2", length = 2048)
+    private String firstImage2;
+
+    @Column(name = "cpyrhtdivcd", length = 20)
+    private String cpyrhtDivCd;
+
+    @Column(name = "mapx", precision = 13, scale = 10)
+    private BigDecimal mapX;
+
+    @Column(name = "mapy", precision = 13, scale = 10)
+    private BigDecimal mapY;
+
+    @Column(name = "mlevel")
+    private Integer mlevel;
+
+    @Column(name = "tel", length = 30)
+    private String tel;
+
+    @Column(name = "telname", length = 50)
+    private String telName;
+
+    @Lob
+    @Column(name = "homepage")
+    private String homepage;
+
+    @Lob
+    @Column(name = "overview")
+    private String overview;
+
+    @Column(name = "zipcode", length = 10)
+    private String zipcode;
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<ContentImage> contentImages = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<ContentInfo> contentInfos = new LinkedHashSet<>();
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Set<RoomInfo> roomInfos = new LinkedHashSet<>();
+
+    // mappedBy 값은 자식 엔티티의 부모 참조 필드 이름 ('content')과 일치
+    @OneToOne(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private ContentIntro contentIntro;
+
+    // mappedBy 값은 자식 엔티티의 부모 참조 필드 이름 ('content')과 일치
+    @OneToOne(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private PetTourInfo petTourInfo;
+
+
+}

--- a/src/main/java/io/github/petty/tour/entity/ContentImage.java
+++ b/src/main/java/io/github/petty/tour/entity/ContentImage.java
@@ -1,0 +1,42 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "content_image")
+@NoArgsConstructor
+@ToString(exclude = "content") // 양방향 관계 시 toString 무한 루프 방지
+public class ContentImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id", nullable = false)
+    private Long id;
+
+
+    // Content 참조 필드 추가
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "contentid") // 실제 DB의 외래 키 컬럼명 지정
+    private Content content;
+
+
+
+
+    @Column(name = "imgname")
+    private String imgName;
+
+    @Column(name = "originimgurl", length = 2048)
+    private String originImgUrl;
+
+    @Column(name = "serialnum", length = 20)
+    private String serialNum;
+
+    @Column(name = "smallimageurl", length = 2048)
+    private String smallImageUrl;
+
+    @Column(name = "cpyrhtdivcd", length = 20)
+    private String cpyrhtDivCd;
+
+}

--- a/src/main/java/io/github/petty/tour/entity/ContentInfo.java
+++ b/src/main/java/io/github/petty/tour/entity/ContentInfo.java
@@ -1,0 +1,39 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "content_info")
+@NoArgsConstructor
+@ToString(exclude = "content")
+public class ContentInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "info_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "contentid")
+    private Content content;
+
+
+    @Column(name = "fldgubun", length = 10)
+    private String fldGubun;
+
+    @Column(name = "infoname", length = 100)
+    private String infoName;
+
+    @Lob
+    @Column(name = "infotext")
+    private String infoText;
+
+    @Column(name = "serialnum", length = 10)
+    private String serialNum;
+
+}

--- a/src/main/java/io/github/petty/tour/entity/ContentIntro.java
+++ b/src/main/java/io/github/petty/tour/entity/ContentIntro.java
@@ -1,0 +1,30 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "content_intro")
+@NoArgsConstructor
+@ToString(exclude = "content")
+public class ContentIntro {
+    @Id
+    @Column(name = "contentid", nullable = false)
+    private Long contentId;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @MapsId
+    @JoinColumn(name = "contentid")
+    private Content content;
+
+    @Column(name = "intro_details")
+    @JdbcTypeCode(SqlTypes.JSON)
+    private Map<String, Object> introDetails;
+
+}

--- a/src/main/java/io/github/petty/tour/entity/PetTourInfo.java
+++ b/src/main/java/io/github/petty/tour/entity/PetTourInfo.java
@@ -1,0 +1,58 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "pet_tour_info")
+@NoArgsConstructor
+@ToString(exclude = "content")
+public class PetTourInfo {
+    @Id
+    @Column(name = "contentid", nullable = false)
+    private Long contentId;
+
+    // 양방향 연관관계를 위한 필드 추가
+    @OneToOne(fetch = FetchType.LAZY) // 필요에 따라 FetchType 변경 가능
+    @MapsId // PetTourInfo의 ID(@Id)가 Content의 ID를 사용하도록 매핑
+    @JoinColumn(name = "contentid") // DB 상의 외래 키 컬럼 지정 (기존 contentid 컬럼 활용)
+    private Content content; // 'content' 필드 추가
+
+    @Lob
+    @Column(name = "rela_acdnt_risk_mtr")
+    private String relaAcdntRiskMtr;
+
+    @Column(name = "acmpy_type_cd", length = 30)
+    private String acmpyTypeCd;
+
+    @Lob
+    @Column(name = "rela_poses_fclty")
+    private String relaPosesFclty;
+
+    @Lob
+    @Column(name = "rela_frnsh_prdlst")
+    private String relaFrnshPrdlst;
+
+    @Lob
+    @Column(name = "etc_acmpy_info")
+    private String etcAcmpyInfo;
+
+    @Lob
+    @Column(name = "rela_purc_prdlst")
+    private String relaPurcPrdlst;
+
+    @Lob
+    @Column(name = "acmpy_psbl_cpam")
+    private String acmpyPsblCpam;
+
+    @Lob
+    @Column(name = "rela_rntl_prdlst")
+    private String relaRntlPrdlst;
+
+    @Lob
+    @Column(name = "acmpy_need_mtr")
+    private String acmpyNeedMtr;
+
+}

--- a/src/main/java/io/github/petty/tour/entity/RoomInfo.java
+++ b/src/main/java/io/github/petty/tour/entity/RoomInfo.java
@@ -1,0 +1,137 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "room_info")
+@NoArgsConstructor
+@ToString(exclude = "content")
+public class RoomInfo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "contentid") // 실제 DB의 외래 키 컬럼명 지정
+    private Content content;
+
+//    @Column(name = "contentid", nullable = false)
+//    private Long contentId;
+
+
+    @Column(name = "roominfono", length = 50)
+    private String roomInfoNo;
+
+    @Column(name = "roomtitle", length = 150)
+    private String roomTitle;
+
+    @Column(name = "roomsize1", length = 20)
+    private String roomSize1;
+
+    @Column(name = "roomcount")
+    private Integer roomCount;
+
+    @Column(name = "roombasecount")
+    private Integer roomBaseCount;
+
+    @Column(name = "roommaxcount")
+    private Integer roomMaxCount;
+
+    @Column(name = "roomoffseasonminfee1", precision = 10)
+    private BigDecimal roomOffSeasonMinFee1;
+
+    @Column(name = "roomoffseasonminfee2", precision = 10)
+    private BigDecimal roomOffSeasonMinFee2;
+
+    @Column(name = "roompeakseasonminfee1", precision = 10)
+    private BigDecimal roomPeakSeasonMinFee1;
+
+    @Column(name = "roompeakseasonminfee2", precision = 10)
+    private BigDecimal roomPeakSeasonMinFee2;
+
+    @Lob
+    @Column(name = "roomintro")
+    private String roomIntro;
+
+    @Column(name = "roombathfacility")
+    private Boolean roomBathFacility;
+
+    @Column(name = "roombath")
+    private Boolean roomBath;
+
+    @Column(name = "roomhometheater")
+    private Boolean roomHomeTheater;
+
+    @Column(name = "roomaircondition")
+    private Boolean roomAirCondition;
+
+    @Column(name = "roomtv")
+    private Boolean roomTv;
+
+    @Column(name = "roompc")
+    private Boolean roomPc;
+
+    @Column(name = "roomcable")
+    private Boolean roomCable;
+
+    @Column(name = "roominternet")
+    private Boolean roomInternet;
+
+    @Column(name = "roomrefrigerator")
+    private Boolean roomRefrigerator;
+
+    @Column(name = "roomtoiletries")
+    private Boolean roomToiletries;
+
+    @Column(name = "roomsofa")
+    private Boolean roomSofa;
+
+    @Column(name = "roomcook")
+    private Boolean roomCook;
+
+    @Column(name = "roomtable")
+    private Boolean roomTable;
+
+    @Column(name = "roomhairdryer")
+    private Boolean roomHairdryer;
+
+    @Column(name = "roomsize2", length = 30)
+    private String roomSize2;
+
+    @Column(name = "roomimg1", length = 2048)
+    private String roomImg1;
+
+    @Column(name = "roomimg1alt")
+    private String roomImg1Alt;
+
+    @Column(name = "roomimg2", length = 2048)
+    private String roomImg2;
+
+    @Column(name = "roomimg2alt")
+    private String roomImg2Alt;
+
+    @Column(name = "roomimg3", length = 2048)
+    private String roomImg3;
+
+    @Column(name = "roomimg3alt")
+    private String roomImg3Alt;
+
+    @Column(name = "roomimg4", length = 2048)
+    private String roomImg4;
+
+    @Column(name = "roomimg4alt")
+    private String roomImg4Alt;
+
+    @Column(name = "roomimg5", length = 2048)
+    private String roomImg5;
+
+    @Column(name = "roomimg5alt")
+    private String roomImg5Alt;
+
+}

--- a/src/main/java/io/github/petty/tour/entity/SyncStatus.java
+++ b/src/main/java/io/github/petty/tour/entity/SyncStatus.java
@@ -1,0 +1,29 @@
+package io.github.petty.tour.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter // lastSyncDate 업데이트를 위해 Setter 필요
+@NoArgsConstructor
+@AllArgsConstructor
+public class SyncStatus {
+
+    @Id
+    private Long id; // 고정 ID
+
+    private LocalDate lastSyncDate; // 마지막으로 성공한 동기화의 대상 날짜
+
+    public static final Long DEFAULT_ID = 1L; // 상태 레코드의 고정 ID
+    // 필요시 ID를 설정하는 생성자 추가 가능
+    public SyncStatus(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/io/github/petty/tour/repository/ContentImageRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/ContentImageRepository.java
@@ -1,0 +1,13 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.ContentImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ContentImageRepository extends JpaRepository<ContentImage, Long> {
+     List<ContentImage> findByContent_ContentId(Long contentId);
+}

--- a/src/main/java/io/github/petty/tour/repository/ContentInfoRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/ContentInfoRepository.java
@@ -1,0 +1,13 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.ContentInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ContentInfoRepository extends JpaRepository<ContentInfo, Long> {
+     List<ContentInfo> findByContent_ContentId(Long contentId);
+}

--- a/src/main/java/io/github/petty/tour/repository/ContentIntroRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/ContentIntroRepository.java
@@ -1,0 +1,14 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.ContentIntro;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ContentIntroRepository extends JpaRepository<ContentIntro, Long> {
+
+    // ContentIntro는 Content와 1:1 관계이며 PK를 공유하므로,
+    // findById(contentId)를 사용하면 됩니다.
+}

--- a/src/main/java/io/github/petty/tour/repository/ContentRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/ContentRepository.java
@@ -1,0 +1,22 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.Content;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ContentRepository extends JpaRepository<Content, Long> {
+
+    List<Content> findByContentId(Long contentId);
+
+
+    /**
+     * 주어진 contentId 목록에 해당하는 Content 및 연관된 모든 데이터(Cascade)를 삭제합니다.
+     * @param contentIds 삭제할 contentId 리스트
+     * @return 삭제된 레코드 수 (반환 타입은 void 또는 long 등 조정 가능)
+     */
+    long deleteAllByContentIdIn(List<Long> contentIds);
+}

--- a/src/main/java/io/github/petty/tour/repository/PetTourInfoRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/PetTourInfoRepository.java
@@ -1,0 +1,13 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.PetTourInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface PetTourInfoRepository extends JpaRepository<PetTourInfo, Long> {
+     // PetTourInfo는 Content와 1:1 관계이며 PK를 공유하므로,
+     // findById(contentId)를 사용하면 됩니다.
+}

--- a/src/main/java/io/github/petty/tour/repository/RoomInfoRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/RoomInfoRepository.java
@@ -1,0 +1,15 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.RoomInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public interface RoomInfoRepository extends JpaRepository<RoomInfo, Long> {
+    // Content ID로 연관된 객실 정보들을 찾는 메소드 (필요시 추가)
+     List<RoomInfo> findByContent_ContentId(Long contentId);
+}

--- a/src/main/java/io/github/petty/tour/repository/SyncStatusRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/SyncStatusRepository.java
@@ -1,0 +1,17 @@
+package io.github.petty.tour.repository;
+
+
+import io.github.petty.tour.entity.SyncStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+public interface SyncStatusRepository extends JpaRepository<SyncStatus, Long> {
+    // SyncStatus는 고정 ID(예: 1L)를 사용할 가능성이 높습니다.
+    // 필요하다면 특정 ID로 조회하는 기본 메소드 외에,
+    // 항상 첫 번째(또는 유일한) 상태 레코드를 가져오는 메소드를 정의할 수 있습니다.
+    Optional<SyncStatus> findTopByOrderByIdAsc();
+}


### PR DESCRIPTION
## 📜 PR 내용 요약


이번 PR은 DB 동기화 기능(`dbsync`)을 위한 데이터 모델을 정의하는 핵심 JPA 엔티티 클래스들을 추가합니다.
주요 콘텐츠(`Content`) 엔티티와 관련된 상세 정보(이미지 `ContentImage`, 소개 `ContentInfo`, `ContentIntro`, 반려동물 동반 정보 `PetTourInfo`, 객실 `RoomInfo` 등) 엔티티 및 동기화 상태(`SyncStatus`) 엔티티를 포함하여, 외부 데이터를 애플리케이션 데이터베이스에 저장하고 관리하기 위한 기반 구조를 마련했습니다.



---


## ⚒️ 작업 및 변경 내용(상세하게)

* **[feat] 엔티티 패키지 구조 생성 및 핵심 도메인 엔티티 추가**
    * `io.github.petty.dbsync.entity` 패키지 생성 및 아래 엔티티 클래스 추가:
    * `Content.java`:
        * 관광 정보, 숙박 시설 등 핵심 콘텐츠 데이터를 나타내는 메인 엔티티.
        * `contentId` (Long)를 기본 키(@Id)로 사용 (DB 자동 생성 아님).
        * 콘텐츠 타입 ID, 제목, 주소, 지역/시군구 코드, 카테고리(cat1/2/3), 생성/수정 시간(`createdTime`/`modifiedTime`, Instant), 대표 이미지 URL, 좌표(mapX/Y), 전화번호, 홈페이지, 개요 등 다양한 정보를 포함.
        * 다른 상세 엔티티들과 연관 관계 설정:
            * `ContentImage`, `ContentInfo`, `RoomInfo`와 1:N (`@OneToMany`, LAZY, CascadeType.ALL, orphanRemoval=true).
            * `ContentIntro`, `PetTourInfo`와 1:1 (`@OneToOne`, LAZY, CascadeType.ALL, orphanRemoval=true).
    * `ContentImage.java`:
        * `Content`에 속한 상세 이미지 정보(이미지명, 원본/작은 이미지 URL, 저작권 구분 코드 등)를 저장하는 엔티티.
        * `imageId` (Long)를 기본 키(@Id)로 사용 (DB 자동 생성 - IDENTITY).
        * `Content` 엔티티와 N:1 관계(@ManyToOne, LAZY, `contentid` 외래 키).
    * `ContentInfo.java`:
        * `Content`에 속한 추가 소개 정보(분류 구분, 정보명, 정보 텍스트 등)를 저장하는 엔티티.
        * `infoId` (Long)를 기본 키(@Id)로 사용 (DB 자동 생성 - IDENTITY).
        * `Content` 엔티티와 N:1 관계(@ManyToOne, LAZY, `contentid` 외래 키).
    * `ContentIntro.java`:
        * `Content`의 소개 정보를 상세히 담는 엔티티 (주로 관광지 타입).
        * `contentId` (Long)를 기본 키(@Id)이자 외래 키(@MapsId)로 사용하여 `Content`와 1:1 관계(LAZY).
        * `introDetails` 필드에 JSON 타입(`@JdbcTypeCode(SqlTypes.JSON)`)으로 다양한 상세 정보 저장.
    * `PetTourInfo.java`:
        * `Content`와 관련된 반려동물 동반 가능 정보(동반 유형 코드, 시설 목록, 필요 물품 등)를 저장하는 엔티티.
        * `contentId` (Long)를 기본 키(@Id)이자 외래 키(@MapsId)로 사용하여 `Content`와 1:1 관계(LAZY).
    * `RoomInfo.java`:
        * `Content`(주로 숙박 시설)에 속한 객실 상세 정보(객실명, 크기, 인원수, 요금, 시설 유무(Boolean 필드 다수), 객실 이미지 URL 등)를 저장하는 엔티티.
        * `roomId` (Long)를 기본 키(@Id)로 사용 (DB 자동 생성 - IDENTITY).
        * `Content` 엔티티와 N:1 관계(@ManyToOne, LAZY, `contentid` 외래 키).
    * `SyncStatus.java`:
        * 데이터 동기화 작업의 마지막 성공 상태(마지막 동기화 날짜 - `lastSyncDate`)를 기록하는 엔티티.
        * 고정된 기본 키 값(예: `DEFAULT_ID = 1L`)을 사용하여 단일 레코드로 상태를 관리.

*(참고: `Content` 엔티티의 `createdTime`, `modifiedTime` 필드는 JPA Auditing 기능을 사용하지 않고 직접 값을 설정/관리)*

---

## 📚 기타 참고 사항

* **리뷰 포인트:**
    * 엔티티 및 필드 네이밍 컨벤션이 일관성 있고 명확한지 확인 부탁드립니다.
    * 선정된 데이터 타입(`Instant`, `BigDecimal`, `@Lob`, `@JdbcTypeCode(SqlTypes.JSON)` 등) 및 컬럼 제약 조건(`nullable`, `length`)이 저장될 데이터 특성에 적합한지 검토해주세요.
    * 엔티티 간 연관 관계 매핑(`@ManyToOne`, `@OneToOne`, `mappedBy`, `@MapsId`) 및 `WorkspaceType.LAZY` 전략이 올바르게 설정되었는지 확인 부탁드립니다.
    * **특히 `CascadeType.ALL` 및 `orphanRemoval=true` 설정:** 연관된 엔티티의 라이프사이클이 부모(`Content`)와 완전히 동일하게 관리됩니다. 부모 엔티티 삭제 시 자식 엔티티가 자동으로 함께 삭제되므로, 이 동작이 의도된 것인지 확인이 필요합니다.
    * 향후 데이터 조회 성능을 고려할 때, 인덱스(Index) 추가가 필요해 보이는 필드(예: `Content`의 `areaCode`, `sigunguCode`, `cat1` 등 검색 조건으로 자주 사용될 필드)가 있는지 검토해주시면 좋겠습니다.

* **데이터베이스 스키마:**
    * 이 엔티티 정의에 따른 실제 DB 테이블 생성/수정은 JPA `hibernate.hbm2ddl.auto` 설정 값(예: `create`, `update`, `validate`, `none`)에 따라 달라집니다. (현재 프로젝트 설정 확인 필요)
    * 만약 `create` 또는 `update` 모드를 사용 중이라면, 애플리케이션 실행 시 스키마 변경이 발생할 수 있습니다. 운영 환경에서는 `validate` 또는 `none` 사용 및 Flyway/Liquibase 같은 마이그레이션 도구 사용을 권장합니다.

* **추가 컨텍스트:**
    * 이 엔티티들은 주로 외부 데이터 소스(예: 공공 데이터 API)로부터 정보를 받아와 저장하는 용도로 사용될 예정입니다. (`Content`의 `contentId`가 자동 생성이 아닌 점, `SyncStatus` 엔티티 존재 등)
    * API 응답/요청 시에는 엔티티를 직접 사용하기보다 필요한 데이터만 포함하는 별도의 DTO(Data Transfer Object)를 정의하여 사용하는 것이 좋습니다. (향후 구현 필요)