### PR TITLE
[LLM] 멀티 데이터소스(Aiven+Supabase) 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
+	maven {
+		name = 'Central Portal Snapshots'
+		url = 'https://central.sonatype.com/repository/maven-snapshots/'
+	}
 }
 
 dependencies {
@@ -44,10 +50,14 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	// ✅ Google Cloud Vision
 	implementation 'com.google.cloud:google-cloud-vision:3.33.0'
-
 	// ✅ AWS SDK v2 - Rekognition
 	implementation platform('software.amazon.awssdk:bom:2.25.19')
 	implementation 'software.amazon.awssdk:rekognition'
+
+	// SpringAI API
+//	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+//	implementation "org.springframework.ai:spring-ai-starter-model-openai"
+//	implementation "org.springframework.ai:spring-ai-starter-vector-store-qdrant"
 }
 
 tasks.named('test') {

--- a/src/main/java/io/github/petty/config/AivenDataSourceConfig.java
+++ b/src/main/java/io/github/petty/config/AivenDataSourceConfig.java
@@ -1,0 +1,85 @@
+package io.github.petty.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AivenDataSourceConfig
+ * 
+ * Aiven MySQL에 저장된 Pet Tour Data를 Spring JPA를 통하여 연결
+ * 
+ * - DB 연결 설정
+ * - JPA Entity 클래스 위치 지정
+ * - JPA Repository 위치 지정
+ * - 트랜잭션(읽기 전용)
+ *
+ */
+
+@Configuration
+// Aiven MySQL Repository 설정
+@EnableTransactionManagement // @Transactional 동작 설정
+@EnableJpaRepositories(
+        basePackages = "io.github.petty.tour.repository",
+        entityManagerFactoryRef = "aivenEntityManagerFactory",
+        transactionManagerRef = "aivenTransactionManager"
+)
+
+public class AivenDataSourceConfig {
+    /**
+     * Aiven MySql 연결 DataSource 생성
+     * yml에서 spring.datasource.aiven.* 가져와서 생성
+     */
+    @Primary
+    @Bean(name="aivenDataSource")
+    @ConfigurationProperties(prefix="spring.datasource.aiven")
+    public DataSource aivenDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    /**
+     * JPA에서 사용할 EntityManagerFactory 설정
+     * JPA DB 연동 - Entity 관리
+     */
+    @Primary
+    @Bean(name="aivenEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean aivenEntityManagerFactory(
+            // datasource 2개 이상일 경우 명시
+            @Qualifier("aivenDataSource") DataSource dataSource,
+            EntityManagerFactoryBuilder builder
+    ) {
+        Map<String, Object> jpaProperties = new HashMap<>();
+        jpaProperties.put("hibernate.physical_naming_strategy", "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+
+        return builder.dataSource(dataSource)
+                .packages("io.github.petty.tour.entity")
+                .persistenceUnit("aiven") // 중복 X
+                .properties(jpaProperties) // 대소문자 구분 X
+                .build();
+    }
+
+    /**
+     * Transaction Manager 설정
+     */
+    @Primary
+    @Bean(name="aivenTransactionManager")
+    public PlatformTransactionManager aivenTransactionManager(
+            @Qualifier("aivenEntityManagerFactory") EntityManagerFactory emf
+    ) {
+        return new JpaTransactionManager(emf);
+    }
+}

--- a/src/main/java/io/github/petty/config/JpaConfig.java
+++ b/src/main/java/io/github/petty/config/JpaConfig.java
@@ -1,0 +1,20 @@
+package io.github.petty.config;
+
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import java.util.HashMap;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public EntityManagerFactoryBuilder entityManagerFactoryBuilder() {
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setGenerateDdl(false);
+
+        return new EntityManagerFactoryBuilder(vendorAdapter, new HashMap<>(), null);
+    }
+}

--- a/src/main/java/io/github/petty/config/SupabaseDataSourceConfig.java
+++ b/src/main/java/io/github/petty/config/SupabaseDataSourceConfig.java
@@ -1,0 +1,88 @@
+package io.github.petty.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * SupabbaseDataSourceConfig
+ *
+ * Supabase PostgreSQL 저장된 Users, Community Spring JPA를 통하여 연결
+ *
+ * - DB 연결 설정
+ * - JPA Entity 클래스 위치 지정
+ * - JPA Repository 위치 지정
+ * - 트랜잭션(읽기 전용)
+ * - Users, Community 두 군데서 사용하므로 멀티 패키지 설정
+ *
+ */
+
+@Configuration
+// Supabase PostgreSQL Repository 설정
+@EnableTransactionManagement // @Transactional 동작 설정
+@EnableJpaRepositories(
+        basePackages = {
+                "io.github.petty.users.repository",
+//                "io.github.petty.community.repository",
+        },
+        entityManagerFactoryRef = "supabaseEntityManagerFactory",
+        transactionManagerRef = "supabaseTransactionManager"
+)
+
+public class SupabaseDataSourceConfig {
+    /**
+     * Supabase PostgreSQL 연결 DataSource 생성
+     * yml에서 spring.datasource.supabase.* 가져와서 생성
+     */
+    @Bean(name="supabaseDataSource")
+    @ConfigurationProperties(prefix="spring.datasource.supabase")
+    public DataSource supabaseDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    /**
+     * JPA에서 사용할 EntityManagerFactory 설정
+     * JPA DB 연동 - Entity 관리
+     */
+    @Bean(name="supabaseEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean supabaseEntityManagerFactory(
+            // datasource 2개 이상일 경우 명시
+            @Qualifier("supabaseDataSource") DataSource dataSource,
+            EntityManagerFactoryBuilder builder
+    ) {
+        Map<String, Object> jpaProperties = new HashMap<>();
+        jpaProperties.put("hibernate.physical_naming_strategy", "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+
+        return builder.dataSource(dataSource)
+                .packages(
+                        "io.github.petty.users.entity"
+//                        "io.github.petty.community.entity"
+                ).persistenceUnit("supabase") // 중복 X
+                .properties(jpaProperties) // 대소문자 구분 X
+                .build();
+    }
+
+    /**
+     * Transaction Manager 설정
+     */
+    @Bean(name="supabaseTransactionManager")
+    public PlatformTransactionManager supabaseTransactionManager(
+            @Qualifier("supabaseEntityManagerFactory") EntityManagerFactory emf
+    ) {
+        return new JpaTransactionManager(emf);
+    }
+}

--- a/src/main/java/io/github/petty/llm/LLMController.java
+++ b/src/main/java/io/github/petty/llm/LLMController.java
@@ -1,4 +1,0 @@
-package io.github.petty.llm;
-
-public class LLMController {
-}

--- a/src/main/java/io/github/petty/llm/LLMService.java
+++ b/src/main/java/io/github/petty/llm/LLMService.java
@@ -1,4 +1,0 @@
-package io.github.petty.llm;
-
-public class LLMService {
-}

--- a/src/main/java/io/github/petty/tour/repository/ContentRepository.java
+++ b/src/main/java/io/github/petty/tour/repository/ContentRepository.java
@@ -3,6 +3,7 @@ package io.github.petty.tour.repository;
 
 import io.github.petty.tour.entity.Content;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,7 +12,10 @@ import java.util.List;
 public interface ContentRepository extends JpaRepository<Content, Long> {
 
     List<Content> findByContentId(Long contentId);
-
+    @Query("""
+        SELECT c FROM Content c
+        LEFT JOIN FETCH c.petTourInfo
+    """)
 
     /**
      * 주어진 contentId 목록에 해당하는 Content 및 연관된 모든 데이터(Cascade)를 삭제합니다.


### PR DESCRIPTION
## 📜 PR 내용 요약
> Tour DB의 MySQL(Aiven)과 Users, Community의 PostgreSQL(Supabase)를 사용하는 멀티 데이터소스 환경을 구성했습니다.
> `AivenDataSourceConfig`, `SupabaseDataSourceConfig`에서 각각의 DB에 대해 DataSource, EntityManagerFactory, TransactionManager를 분리 설정했습니다.
> snake_case 자동 변환 적용이 되도록 구성하였습니다.

<br>

## ⚒️ 작업 및 변경 내용
### 멀티 데이터 소스 관련
- <b> 멀티 데이터소스 수동 설정 </b>
   - Aiven(MySQL) : `@Primary` 설정 (추후 고려 대상)
   - Supabase(PostgreSQL) 데이터소스 설정
- 각 DB별로 Enitiy / Repostiory 패키지 적용 
- Hibernate 환경에 맞춘 Naming Strategy 설정 적용
   - snake_case 자동 매핑을 위하여 `CamelCaseToUnderscoresNamingStrategy` 설정

### RAG 관련
- 향후 RAG 전처리 텍스트 생성에 사용하기 위해 `ContentRepository`에 join 쿼스텀쿼리 일부를 추가하였습니다.

<br>

## 📚 기타 참고 사항
- ❗ Community 파트의 경우 아직 Repository 패키지가 설정되어 있지 않아, `SupabaseDataSourceConfig` 내에서 주석 처리 하였습니다
- ❗ 현재 Vision 파트의 json 설정이 빠져 있어, 테스트 시 파트 담당자에게 문의 필요합니다.
- ❗ SpringAI 관련 의존성 주석 처리되어 있습니다.
-  `CommandLineRunner`를 이용하여 각 DB 연결 확인 완료하였습니다. 추후 test code 작성을 통한 테스트로 변경해보려 합니다.