### PR TITLE
[USER] 카카오 OAuth2 로그인 기능 추가

### DIFF
--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -60,11 +60,10 @@
             border: 0;
             border-top: 1px solid #ddd;
         }
-        .github-button {
+        /* Common social button styles */
+        .social-button {
             width: 100%;
             padding: 10px;
-            background-color: #333;
-            color: white;
             border: none;
             border-radius: 4px;
             font-size: 16px;
@@ -72,14 +71,33 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            margin-bottom: 10px; /* Add some space between social buttons */
+        }
+        .social-icon {
+            margin-right: 10px;
+            width: 20px;
+            height: 20px;
+        }
+
+        /* GitHub button specific styles */
+        .github-button {
+            background-color: #333;
+            color: white;
         }
         .github-button:hover {
             background-color: #555;
         }
-        .github-icon {
-            margin-right: 10px;
-            width: 20px;
-            height: 20px;
+
+        /* Kakao button specific styles */
+        .kakao-button {
+            background-color: #FEE500; /* Kakao yellow */
+            color: #3C1E1E; /* Dark brown for text */
+        }
+        .kakao-button:hover {
+            background-color: #FFDE00; /* Lighter yellow on hover */
+        }
+        .kakao-button .social-icon {
+            fill: #3C1E1E; /* Fill color for Kakao icon */
         }
     </style>
 </head>
@@ -101,8 +119,17 @@
     <div class="social-login">
         <hr>
         <p>소셜 계정으로 로그인</p>
-        <button class="github-button" onclick="location.href='/oauth2/authorization/github'">
-            <svg class="github-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
+
+        <button class="social-button kakao-button" onclick="location.href='/oauth2/authorization/kakao'">
+            <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <!-- 카카오톡 말풍선 아이콘 스타일 -->
+                <path fill="black" d="M12 2C6.48 2 2 5.94 2 10.5c0 2.67 1.64 5.03 4.18 6.5-.2.75-.7 2.05-.8 2.3 0 0-.01.1.05.14.06.04.14 0 .14 0 .18-.03 2.1-1.4 2.96-2.03.77.16 1.57.26 2.47.26 5.52 0 10-3.94 10-8.5S17.52 2 12 2z"/>
+            </svg>
+            카카오로 로그인
+        </button>
+
+        <button class="social-button github-button" onclick="location.href='/oauth2/authorization/github'">
+            <svg class="social-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
             </svg>
             GitHub로 로그인
@@ -126,7 +153,7 @@
             });
 
             if (response.ok) {
-                    window.location.href = '/';
+                window.location.href = '/';
                 // }
             } else {
                 alert('로그인 실패');


### PR DESCRIPTION
## 📜 PR 내용 요약
- **카카오 OAuth2 인증 추가:** Spring Security OAuth2 클라이언트 설정에 카카오 등록 정보를 추가했습니다.
- **`CustomOAuth2UserService` 수정:** 카카오 OAuth2 사용자 정보를 정상적으로 로드하고 처리할 수 있도록 로직을 확장했습니다.
- **`login.html` 수정:** 로그인 페이지에 카카오 로그인 버튼을 추가하고 소셜 로그인 버튼 스타일을 개선했습니다.

## ⚒️ 작업 및 변경 내용(상세하게)
### 1. 백엔드 - 카카오 OAuth2 연동 로직 추가
- **`CustomOAuth2UserService.java` 수정:**
    - 기존에 GitHub OAuth2 사용자 정보만 처리하던 `CustomOAuth2UserService`를 수정하여 **카카오 OAuth2 사용자를 처리하는 로직을 추가**했습니다.
    - **`extractEmail` 메서드 개선:**
        - 기존에는 GitHub 사용자의 이메일 추출 로직만 있었으나, `registrationId`가 "kakao"인 경우를 추가했습니다.
        - 카카오 응답(`attributes`)에서 `kakao_account` 맵을 확인하고 `email` 필드를 추출합니다.
        - **이메일 정보 제공에 동의하지 않은 사용자의 경우**를 위해 대체 로직을 추가했습니다. `properties` 맵에서 `nickname`을 추출하여 `[닉네임]@kakao.com` 형태의 이메일을 생성하도록 했습니다.
    - **`saveOrUpdate` 메서드 개선:**
        - 사용자 정보를 저장하거나 업데이트할 때, **프로바이더(provider)에 따라 `displayName`을 설정하는 로직을 추가**했습니다.
        - "github" 프로바이더의 경우 기존처럼 `name` 또는 `login` 속성을 사용합니다.
        - "kakao" 프로바이더의 경우, `properties` 맵에서 `nickname` 속성을 추출하여 `displayName`으로 설정합니다. 닉네임 정보가 없는 경우 이메일 주소 앞 부분을 사용합니다.

### 2. 프론트엔드 - 로그인 페이지 UI 업데이트
- **`login.html` 수정:**
    - **소셜 로그인 버튼 스타일 공용화:** 기존 `github-button`에 적용되어 있던 스타일 중 공통적인 부분을 `social-button` 클래스로 분리하여 정의했습니다.
    - 각 소셜 버튼(`github-button`, 새로 추가된 `kakao-button`)은 `social-button` 클래스를 상속받고, 프로바이더별 고유 스타일(배경색, 텍스트 색상 등)을 추가했습니다.
    -  **카카오 로그인 버튼 추가:** `<a href="/oauth2/authorization/kakao">` 링크를 포함하는 새로운 버튼 구조를 추가했습니다. 이 링크는 Spring Security OAuth2가 제공하는 카카오 인증 시작 엔드포인트로 연결됩니다. 버튼은 새로운 `.kakao-button` 클래스와 `.social-icon` 클래스를 사용하여 스타일링됩니다.
    - 기존 "소셜 계정으로 로그인" 섹션에 "카카오로 로그인" 버튼이 추가되어 노출됩니다.

## 📚 기타 참고 사항
- 카카오 OAuth2 기능을 사용하기 위해서는 **카카오 개발자 센터에 애플리케이션을 등록**하고, 해당 Client ID 및 Secret 등의 설정값을 백엔드 애플리케이션의 `application-secret.yml` 파일에 추가해야 합니다. (현재 완료)
- 카카오 로그인 시 사용자가 **이메일 정보 제공에 동의하지 않는 경우**, 닉네임 기반으로 대체 이메일이 생성되어 사용됩니다.
- 로그인 페이지 UI 변경으로 소셜 로그인 버튼 디자인의 일관성이 향상되었습니다.