### PR TITLE
[USER] 닉네임 자동 생성 및 프로필 편집 기능 구현

### DIFF
--- a/src/main/java/io/github/petty/users/controller/UsersApiController.java
+++ b/src/main/java/io/github/petty/users/controller/UsersApiController.java
@@ -7,8 +7,6 @@ import io.github.petty.users.jwt.JWTUtil;
 import io.github.petty.users.service.EmailService;
 import io.github.petty.users.service.RefreshTokenService;
 import io.github.petty.users.util.CookieUtils;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/io/github/petty/users/controller/UsersApiController.java
+++ b/src/main/java/io/github/petty/users/controller/UsersApiController.java
@@ -6,6 +6,7 @@ import io.github.petty.users.dto.VerifyCodeRequest;
 import io.github.petty.users.jwt.JWTUtil;
 import io.github.petty.users.service.EmailService;
 import io.github.petty.users.service.RefreshTokenService;
+import io.github.petty.users.service.UserService;
 import io.github.petty.users.util.CookieUtils;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
@@ -24,12 +25,14 @@ import java.util.UUID;
 public class UsersApiController {
 
     private final JWTUtil jwtUtil;
+    private final UserService userService;
     private final EmailService emailService;
     private final RefreshTokenService refreshTokenService;
 
 
-    public UsersApiController(JWTUtil jwtUtil, EmailService emailService, RefreshTokenService refreshTokenService) {
+    public UsersApiController(JWTUtil jwtUtil, EmailService emailService, RefreshTokenService refreshTokenService, UserService userService) {
         this.jwtUtil = jwtUtil;
+        this.userService = userService;
         this.emailService = emailService;
         this.refreshTokenService = refreshTokenService;
     }
@@ -99,5 +102,28 @@ public class UsersApiController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", e.getMessage()));
         }
+    }
+
+    // 닉네임 중복 검사 API 추가
+    @GetMapping("/check-displayname")
+    public ResponseEntity<Map<String, Object>> checkDisplayName(
+            @RequestParam String displayName) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth instanceof AnonymousAuthenticationToken) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        // 현재 사용자 ID 가져오기
+        UUID currentUserId = userService.getCurrentUserId(auth.getPrincipal());
+
+        // 한 번의 서비스 호출로 모든 정보 가져오기
+        Map<String, Object> result = userService.checkDisplayName(currentUserId, displayName);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("available", result.get("available"));
+        response.put("message", result.get("message"));
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/io/github/petty/users/controller/UsersController.java
+++ b/src/main/java/io/github/petty/users/controller/UsersController.java
@@ -1,14 +1,9 @@
 package io.github.petty.users.controller;
 
-import io.github.petty.users.dto.CustomUserDetails;
 import io.github.petty.users.dto.JoinDTO;
 import io.github.petty.users.dto.UserProfileEditDTO;
-import io.github.petty.users.entity.Users;
 import io.github.petty.users.service.JoinService;
 import io.github.petty.users.service.UserService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
@@ -16,7 +11,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.security.core.Authentication;
 

--- a/src/main/java/io/github/petty/users/dto/JoinDTO.java
+++ b/src/main/java/io/github/petty/users/dto/JoinDTO.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 public class JoinDTO {
     private String username;
     private String password;
-    private String displayName;
+    private String name;
     private String phone;
-
 }

--- a/src/main/java/io/github/petty/users/dto/UserProfileEditDTO.java
+++ b/src/main/java/io/github/petty/users/dto/UserProfileEditDTO.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserProfileEditDTO {
-    private String displayName;  // 사용자 이름
+    private String name;         // 사용자 이름
+    private String displayName;  // 닉네임
     private String phone;        // 전화번호
 }

--- a/src/main/java/io/github/petty/users/entity/Users.java
+++ b/src/main/java/io/github/petty/users/entity/Users.java
@@ -25,7 +25,10 @@ public class Users {
     private String password;
 
     @Column(nullable = false, length = 50)
-    private String displayName;
+    private String name;
+
+    @Column(nullable = false, length = 50, unique = true)
+    private String displayName; // 닉네임 (자동 생성)
 
     @Column(length = 20)
     private String phone;

--- a/src/main/java/io/github/petty/users/repository/UsersRepository.java
+++ b/src/main/java/io/github/petty/users/repository/UsersRepository.java
@@ -9,4 +9,6 @@ public interface UsersRepository extends JpaRepository<Users, UUID> {
     Boolean existsByUsername(String username);
 
     Users findByUsername(String username);
+
+    Boolean existsByDisplayName(String displayName);
 }

--- a/src/main/java/io/github/petty/users/service/EmailService.java
+++ b/src/main/java/io/github/petty/users/service/EmailService.java
@@ -11,6 +11,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
+import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.util.Random;
 
@@ -35,7 +36,7 @@ public class EmailService {
         try {
             sendEmail(email, code);
             return true;
-        } catch (MessagingException e) {
+        } catch (MessagingException | UnsupportedEncodingException e) {
             log.error("이메일 전송 실패: {}", e.getMessage());
             return false;
         }
@@ -46,19 +47,19 @@ public class EmailService {
         return String.format("%06d", random.nextInt(1000000)); // 000000 ~ 999999
     }
 
-    private void sendEmail(String toEmail, String code) throws MessagingException {
+    private void sendEmail(String toEmail, String code) throws MessagingException, UnsupportedEncodingException {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "utf-8");
 
-        helper.setFrom("krpetty54@gmail.com");  // 보내는 사람 이메일 (본인의 실제 이메일 주소로 변경)
+        helper.setFrom("krpetty54@gmail.com", "Petty Team");
         helper.setTo(toEmail);
-        helper.setSubject("[Petty] 이메일 인증 코드입니다.");
+        helper.setSubject("Petty 인증 코드");
 
         // HTML 형식의 이메일 본문
         String htmlContent = "<div style='background-color:#ffffff;padding:40px;border-radius:8px;text-align:center;max-width:400px;width:100%;margin:0 auto'>" +
-                "<a href='https://github.com/PETTY-HUB' style='display:block;margin-bottom:20px;text-decoration:none;color:#000000;width:5.5rem;font-weight:bold' target='_blank'>" +
+                "<div style='display:block;margin-bottom:20px;text-decoration:none;color:#000000;width:5.5rem;font-weight:bold' target='_blank'>" +
                 "<h2 style='color:#f39c12'>Petty</h2>" +
-                "</a>" +
+                "</div>" +
                 "<div style='text-align:center'>" +
                 "<p style='color:#212529;font-size:18px;font-weight:600'>인증 번호</p>" +
                 "</div>" +
@@ -66,19 +67,18 @@ public class EmailService {
                 "<p style='font-size:35px;font-weight:bold;line-height:1.5;color:#f39c12;margin:10px 0 0'>" + code + "</p>" +
                 "</div>" +
                 "<p style='display:inline-block;padding:15px 0;color:#888888;text-decoration:none;border-radius:8px;font-size:16px;word-break:keep-all;text-align:left'>" +
-                "Petty의 더 많은 서비스를 이용하려면 이메일 인증이 필요해요.<br>" +
-                "인증번호를 입력하고 인증을 완료해 주세요!<br>" +
-                "(스팸함에 있을 수도 있으니 한 번 확인 부탁드려요!)" +
+                "위 코드를 입력하여 이메일 인증을 완료해주세요.<br>" +
+                "이 코드는 5분간 유효합니다.<br>" +
                 "</p>" +
                 "<div style='margin-top:20px; font-size:14px; color:#888;'>" +
-                "이 메일은 5분간 유효합니다." +
+                "본 메일은 발신전용입니다." +
                 "</div>" +
                 "</div>";
 
         helper.setText(htmlContent, true);
 
         javaMailSender.send(mimeMessage);
-        log.info("이메일 ({})로 인증 코드 ({})를 성공적으로 전송했습니다.", toEmail, code);
+        log.info("이메일 ({})로 인증 코드를 성공적으로 전송했습니다.", toEmail);
     }
 
     // 인증 코드 확인

--- a/src/main/java/io/github/petty/users/service/JoinService.java
+++ b/src/main/java/io/github/petty/users/service/JoinService.java
@@ -4,6 +4,7 @@ import io.github.petty.users.Role;
 import io.github.petty.users.dto.JoinDTO;
 import io.github.petty.users.entity.Users;
 import io.github.petty.users.repository.UsersRepository;
+import io.github.petty.users.util.DisplayNameGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -14,11 +15,12 @@ public class JoinService {
 
     private final UsersRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final DisplayNameGenerator displayNameGenerator;
 
     public boolean joinProcess(JoinDTO joinDTO) {
         String username = joinDTO.getUsername();
         String password = joinDTO.getPassword();
-        String displayName = joinDTO.getDisplayName();
+        String name = joinDTO.getName();
         String phone = joinDTO.getPhone();
         String encodedPassword = bCryptPasswordEncoder.encode(password);
 
@@ -30,10 +32,14 @@ public class JoinService {
         Users users = new Users();
         users.setUsername(username);
         users.setPassword(encodedPassword);
-        users.setDisplayName(displayName);
+        users.setName(name);
         users.setPhone(phone);
         users.setRole(Role.ROLE_USER.name());
         users.setProvider("local");
+
+        String uniqueDisplayName = displayNameGenerator.generateUniqueDisplayName();
+        users.setDisplayName(uniqueDisplayName);
+
         userRepository.save(users);
 
         return true;

--- a/src/main/java/io/github/petty/users/service/UserService.java
+++ b/src/main/java/io/github/petty/users/service/UserService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -48,16 +50,11 @@ public class UserService {
         return null;
     }
 
-
-
-
-
-
     // 사용자 정보 가져오기
     public UserProfileEditDTO getUserById(UUID userId) {
         Users user = usersRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
-        return new UserProfileEditDTO(user.getDisplayName(), user.getPhone());
+        return new UserProfileEditDTO(user.getName(), user.getDisplayName(), user.getPhone());
 
     }
 
@@ -66,9 +63,44 @@ public class UserService {
         Users user = usersRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
+        // 닉네임 중복 검사
+        String newDisplayName = userProfileEditDTO.getDisplayName();
+        if (!user.getDisplayName().equals(newDisplayName)) {
+            if (usersRepository.existsByDisplayName(newDisplayName)) {
+                throw new RuntimeException("이미 사용 중인 닉네임입니다.");
+            }
+        }
+
+        user.setName(userProfileEditDTO.getName());
         user.setDisplayName(userProfileEditDTO.getDisplayName());
         user.setPhone(userProfileEditDTO.getPhone());
 
         return usersRepository.save(user);
+    }
+
+    // 닉네임 유효성 검사
+    public Map<String, Object> checkDisplayName(UUID currentUserId, String displayName) {
+        boolean isCurrentUserDisplayName = isCurrentUserDisplayName(currentUserId, displayName);
+        boolean isAvailable = !usersRepository.existsByDisplayName(displayName) || isCurrentUserDisplayName;
+
+        String message;
+        if (isCurrentUserDisplayName) {
+            message = "현재 사용 중인 닉네임입니다.";
+        } else if (isAvailable) {
+            message = "사용 가능한 닉네임입니다.";
+        } else {
+            message = "이미 사용 중인 닉네임입니다.";
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("available", isAvailable);
+        result.put("message", message);
+        return result;
+    }
+
+    // 현재 사용자의 닉네임인지 확인
+    public boolean isCurrentUserDisplayName(UUID userId, String displayName) {
+        Users user = usersRepository.findById(userId).orElse(null);
+        return user != null && displayName.equals(user.getDisplayName());
     }
 }

--- a/src/main/java/io/github/petty/users/util/DisplayNameGenerator.java
+++ b/src/main/java/io/github/petty/users/util/DisplayNameGenerator.java
@@ -1,0 +1,62 @@
+package io.github.petty.users.util;
+
+import io.github.petty.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class DisplayNameGenerator {
+
+    private final UsersRepository usersRepository;
+    private final Random random = new Random();
+
+    // 귀여운 형용사들
+    private static final String[] ADJECTIVES = {
+            "귀여운", "활발한", "똑똑한", "용감한", "착한", "재미있는", "친근한", "사랑스러운",
+            "깜찍한", "멋진", "예쁜", "훌륭한", "행복한", "밝은", "따뜻한", "부드러운"
+    };
+
+    // 반려동물들
+    private static final String[] ANIMALS = {
+            "강아지", "고양이", "햄스터", "토끼", "앵무새", "거북이", "금붕어", "페럿",
+            "친칠라", "기니피그", "고슴도치", "이구아나", "카나리아", "문조", "코카티엘", "잉꼬"
+    };
+
+    // 유니크 displayName 생성
+    public String generateUniqueDisplayName() {
+        String candidate;
+        int attempts = 0;
+        final int MAX_ATTEMPTS = 50;
+
+        do {
+            candidate = generateCuteDisplayName();
+            attempts++;
+
+            // 50번 실패하면 UUID 폴백
+            if (attempts >= MAX_ATTEMPTS) {
+                candidate = generateUuidFallback();
+                break;
+            }
+        } while (usersRepository.existsByDisplayName(candidate));
+
+        return candidate;
+    }
+
+    // 형용사 + 동물 + 3자리 숫자
+    private String generateCuteDisplayName() {
+        String adjective = ADJECTIVES[random.nextInt(ADJECTIVES.length)];
+        String animal = ANIMALS[random.nextInt(ANIMALS.length)];
+        String number = String.format("%03d", random.nextInt(1000));
+
+        return adjective + animal + number;
+    }
+
+    // UUID 기반 폴백 닉네임 (만약의 경우)
+    private String generateUuidFallback() {
+        String uuid = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        return "petty_" + uuid;
+    }
+}

--- a/src/main/resources/templates/join.html
+++ b/src/main/resources/templates/join.html
@@ -250,8 +250,8 @@
 
             <div class="form-group">
                 <label for="name">이름</label>
-                <input type="text" id="name" class="form-control" required placeholder="이름을 입력해주세요" th:field="*{displayName}">
-                <div class="error-message" th:errors="*{displayName}"></div>
+                <input type="text" id="name" class="form-control" required placeholder="이름을 입력해주세요" th:field="*{name}">
+                <div class="error-message" th:errors="*{name}"></div>
             </div>
 
             <div class="form-group">

--- a/src/main/resources/templates/profile_edit.html
+++ b/src/main/resources/templates/profile_edit.html
@@ -2,7 +2,7 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>프로필 수정</title>
+    <title>프로필 수정 - Petty</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -13,52 +13,133 @@
         h2 {
             color: #f1c40f;
             text-align: center;
+            margin-bottom: 30px;
         }
         .profile-container {
-            max-width: 400px;
+            max-width: 500px;
             margin: 0 auto;
             background-color: #fff;
-            padding: 20px;
+            padding: 30px;
             border-radius: 8px;
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
         }
         .form-group {
-            margin-bottom: 15px;
+            margin-bottom: 20px;
         }
         label {
             font-weight: bold;
             color: #f39c12;
             display: block;
-            margin-bottom: 5px;
+            margin-bottom: 8px;
         }
         input[type="text"] {
             width: 100%;
-            padding: 10px;
-            border: 1px solid #f39c12;
-            border-radius: 4px;
+            padding: 12px;
+            border: 2px solid #ddd;
+            border-radius: 6px;
             box-sizing: border-box;
+            font-size: 16px;
+            transition: border-color 0.3s;
         }
-        button {
+        input[type="text"]:focus {
+            outline: none;
+            border-color: #f39c12;
+        }
+        input.invalid {
+            border-color: #e74c3c;
+        }
+        input.valid {
+            border-color: #27ae60;
+        }
+        .input-group {
+            display: flex;
+            gap: 10px;
+            align-items: flex-start;
+        }
+        .input-group input {
+            flex: 1;
+        }
+        .check-btn {
+            padding: 12px 20px;
+            background-color: #e67e22;  /* 주황색으로 변경 */
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 14px;
+            white-space: nowrap;
+            transition: background-color 0.3s;
+        }
+        .check-btn:hover {
+            background-color: #d35400;  /* 호버 시 더 진한 주황색 */
+        }
+        .check-btn:disabled {
+            background-color: #bdc3c7;
+            cursor: not-allowed;
+        }
+        .submit-btn {
             width: 100%;
-            padding: 10px;
+            padding: 15px;
             background-color: #f39c12;
             color: white;
             border: none;
-            border-radius: 4px;
-            font-size: 16px;
+            border-radius: 6px;
+            font-size: 18px;
             cursor: pointer;
+            transition: background-color 0.3s;
+            margin-top: 10px;
         }
-        button:hover {
+        .submit-btn:hover {
             background-color: #f1c40f;
         }
-        .error {
-            color: red;
-            font-size: 0.9em;
-            margin-top: 5px;
-            display: none;
+        .submit-btn:disabled {
+            background-color: #bdc3c7;
+            cursor: not-allowed;
         }
-        input.invalid {
-            border-color: red;
+        .message {
+            margin-top: 8px;
+            font-size: 14px;
+            min-height: 20px;
+        }
+        .error {
+            color: #e74c3c;
+        }
+        .success {
+            color: #27ae60;
+        }
+        .warning {
+            color: #f39c12;
+        }
+        .back-link {
+            display: block;
+            text-align: center;
+            margin-top: 20px;
+            color: #f39c12;
+            text-decoration: none;
+        }
+        .back-link:hover {
+            text-decoration: underline;
+        }
+        .loading {
+            text-align: center;
+            color: #666;
+            padding: 20px;
+        }
+        .alert {
+            margin-bottom: 20px;
+            padding: 12px;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+        .alert-error {
+            background-color: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        .alert-success {
+            background-color: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
         }
     </style>
 </head>
@@ -66,42 +147,297 @@
 
 <h2>프로필 수정</h2>
 <div class="profile-container">
-    <form id="editProfileForm" th:action="@{/profile/update}" th:object="${userProfile}" method="post" novalidate>
+
+    <!-- 에러/성공 메시지 표시 -->
+    <div th:if="${errorMessage}" class="alert alert-error" th:text="${errorMessage}"></div>
+    <div th:if="${successMessage}" class="alert alert-success" th:text="${successMessage}"></div>
+
+    <div id="loadingDiv" class="loading">
+        프로필 정보를 불러오는 중...
+    </div>
+
+    <!-- th:object를 사용하여 userProfile 객체 바인딩 -->
+    <form id="editProfileForm" th:action="@{/profile/update}" method="post" th:object="${userProfile}" style="display: none;">
+
         <div class="form-group">
-            <label for="displayName">사용자 이름</label>
-            <input type="text" id="displayName" name="displayName" th:field="*{displayName}" required>
+            <label for="name">이름</label>
+            <input type="text" id="name" name="name" th:field="*{name}" required>
+            <div class="message" id="nameMessage"></div>
         </div>
+
+        <div class="form-group">
+            <label for="displayName">닉네임</label>
+            <div class="input-group">
+                <input type="text" id="displayName" name="displayName" th:field="*{displayName}" required>
+                <button type="button" class="check-btn" id="checkDisplayNameBtn">중복 확인</button>
+            </div>
+            <div class="message" id="displayNameMessage"></div>
+        </div>
+
         <div class="form-group">
             <label for="phone">전화번호</label>
-            <input type="text" id="phone" name="phone" th:field="*{phone}" required>
-            <div class="error" id="phoneError">유효한 전화번호를 입력해주세요. (예: 01012345678)</div>
+            <input type="text" id="phone" name="phone" th:field="*{phone}" required placeholder="01012345678">
+            <div class="message" id="phoneMessage"></div>
         </div>
-        <button type="submit">수정하기</button>
+
+        <button type="submit" class="submit-btn" id="submitBtn">프로필 수정</button>
     </form>
+
+    <a href="/" class="back-link">← 메인으로 돌아가기</a>
 </div>
 
-<script>
-    document.addEventListener('DOMContentLoaded', function() {
-        const form = document.getElementById('editProfileForm');
-        const phoneInput = document.getElementById('phone');
-        const phoneErrorElement = document.getElementById('phoneError');
+<script th:inline="javascript">
+    let isDisplayNameChecked = false;
+    let isDisplayNameValid = false;
+    let originalDisplayName = '';
 
-        form.addEventListener('submit', function(e) {
+    // Thymeleaf에서 서버 데이터를 JavaScript 변수로 주입
+    /*<![CDATA[*/
+    const userProfileData = {
+        name: /*[[${userProfile?.name}]]*/ '',
+        displayName: /*[[${userProfile?.displayName}]]*/ '',
+        phone: /*[[${userProfile?.phone}]]*/ ''
+    };
+    /*]]*/
+
+    document.addEventListener('DOMContentLoaded', async function() {
+        await loadUserProfile();
+        initializeFormValidation();
+    });
+
+    // 사용자 프로필 정보 로드 (토큰 갱신 로직 포함)
+    async function loadUserProfile() {
+        try {
+            const response = await fetch('/api/users/me');
+
+            if (response.ok) {
+                // 성공: 프로필 폼 표시 (Thymeleaf가 이미 데이터 주입함)
+                showProfileForm();
+            } else if (response.status === 401) {
+                // 액세스 토큰 만료: 자동 갱신 시도
+                console.log('액세스 토큰 만료, 리프레시 토큰으로 갱신 시도');
+
+                try {
+                    const refreshResponse = await fetch('/api/auth/refresh', {
+                        method: 'POST'
+                    });
+
+                    if (refreshResponse.ok) {
+                        console.log('토큰 갱신 성공! 프로필 로드 재시도');
+                        return await loadUserProfile();
+                    } else {
+                        console.log('리프레시 토큰도 만료, 로그인 필요');
+                        redirectToLogin();
+                    }
+                } catch (refreshError) {
+                    console.error('토큰 갱신 실패:', refreshError);
+                    redirectToLogin();
+                }
+            } else {
+                redirectToLogin();
+            }
+        } catch (error) {
+            console.error('프로필 정보 조회 실패:', error);
+            redirectToLogin();
+        }
+    }
+
+    function showProfileForm() {
+        document.getElementById('loadingDiv').style.display = 'none';
+        document.getElementById('editProfileForm').style.display = 'block';
+    }
+
+    function redirectToLogin() {
+        alert('로그인이 필요합니다.');
+        window.location.href = '/login';
+    }
+
+    function initializeFormValidation() {
+        const form = document.getElementById('editProfileForm');
+        const nameInput = document.getElementById('name');
+        const displayNameInput = document.getElementById('displayName');
+        const phoneInput = document.getElementById('phone');
+        const checkDisplayNameBtn = document.getElementById('checkDisplayNameBtn');
+        const submitBtn = document.getElementById('submitBtn');
+
+        const nameMessage = document.getElementById('nameMessage');
+        const displayNameMessage = document.getElementById('displayNameMessage');
+        const phoneMessage = document.getElementById('phoneMessage');
+
+        // Thymeleaf가 주입한 값 또는 서버 데이터 사용
+        originalDisplayName = displayNameInput.value || userProfileData.displayName || '';
+
+        // 이름 검증
+        nameInput.addEventListener('input', function() {
+            const name = this.value.trim();
+            if (name.length < 2) {
+                nameMessage.textContent = '이름은 2글자 이상 입력해주세요.';
+                nameMessage.className = 'message error';
+                this.classList.add('invalid');
+                this.classList.remove('valid');
+            } else {
+                nameMessage.textContent = '';
+                this.classList.remove('invalid');
+                this.classList.add('valid');
+            }
+            updateSubmitButton();
+        });
+
+        // 닉네임 입력 시 중복확인 상태 초기화
+        displayNameInput.addEventListener('input', function() {
+            const currentDisplayName = this.value.trim();
+            if (currentDisplayName === originalDisplayName) {
+                displayNameMessage.textContent = '현재 사용 중인 닉네임입니다.';
+                displayNameMessage.className = 'message warning';
+                isDisplayNameChecked = true;
+                isDisplayNameValid = true;
+                this.classList.remove('invalid');
+                this.classList.add('valid');
+            } else {
+                isDisplayNameChecked = false;
+                isDisplayNameValid = false;
+                displayNameMessage.textContent = '닉네임 중복 확인이 필요합니다.';
+                displayNameMessage.className = 'message error';
+                this.classList.remove('valid', 'invalid');
+            }
+            updateSubmitButton();
+        });
+
+        // 닉네임 중복 확인 (토큰 갱신 로직 포함)
+        checkDisplayNameBtn.addEventListener('click', async function() {
+            const displayName = displayNameInput.value.trim();
+
+            if (!displayName) {
+                displayNameMessage.textContent = '닉네임을 입력해주세요.';
+                displayNameMessage.className = 'message error';
+                return;
+            }
+
+            if (displayName.length < 2) {
+                displayNameMessage.textContent = '닉네임은 2글자 이상 입력해주세요.';
+                displayNameMessage.className = 'message error';
+                return;
+            }
+
+            // 버튼 비활성화
+            this.disabled = true;
+            this.textContent = '확인 중...';
+            displayNameMessage.textContent = '중복 확인 중...';
+            displayNameMessage.className = 'message';
+
+            try {
+                const response = await fetch(`/api/check-displayname?displayName=${encodeURIComponent(displayName)}`);
+
+                if (response.ok) {
+                    const data = await response.json();
+                    handleDisplayNameCheckResult(data);
+                } else if (response.status === 401) {
+                    // 토큰 만료 시 갱신 후 재시도
+                    const refreshResponse = await fetch('/api/auth/refresh', { method: 'POST' });
+
+                    if (refreshResponse.ok) {
+                        // 토큰 갱신 성공, 재시도
+                        const retryResponse = await fetch(`/api/check-displayname?displayName=${encodeURIComponent(displayName)}`);
+                        if (retryResponse.ok) {
+                            const data = await retryResponse.json();
+                            handleDisplayNameCheckResult(data);
+                        } else {
+                            throw new Error('재시도 실패');
+                        }
+                    } else {
+                        redirectToLogin();
+                        return;
+                    }
+                } else {
+                    throw new Error('서버 오류');
+                }
+            } catch (error) {
+                console.error('Error:', error);
+                displayNameMessage.textContent = '서버 오류가 발생했습니다. 다시 시도해주세요.';
+                displayNameMessage.className = 'message error';
+                isDisplayNameChecked = false;
+                isDisplayNameValid = false;
+            } finally {
+                // 버튼 활성화
+                this.disabled = false;
+                this.textContent = '중복 확인';
+                updateSubmitButton();
+            }
+        });
+
+        function handleDisplayNameCheckResult(data) {
+            isDisplayNameChecked = true;
+            isDisplayNameValid = data.available;
+
+            if (data.available) {
+                displayNameMessage.textContent = data.message;
+                displayNameMessage.className = 'message success';
+                displayNameInput.classList.remove('invalid');
+                displayNameInput.classList.add('valid');
+            } else {
+                displayNameMessage.textContent = data.message;
+                displayNameMessage.className = 'message error';
+                displayNameInput.classList.remove('valid');
+                displayNameInput.classList.add('invalid');
+            }
+        }
+
+        // 전화번호 검증
+        phoneInput.addEventListener('input', function() {
+            const phone = this.value.trim();
+            const phoneRegex = /^01[016789]\d{7,8}$/;
+
+            if (!phoneRegex.test(phone)) {
+                phoneMessage.textContent = '유효한 전화번호를 입력해주세요. (예: 01012345678)';
+                phoneMessage.className = 'message error';
+                this.classList.add('invalid');
+                this.classList.remove('valid');
+            } else {
+                phoneMessage.textContent = '';
+                this.classList.remove('invalid');
+                this.classList.add('valid');
+            }
+            updateSubmitButton();
+        });
+
+        // 제출 버튼 상태 업데이트
+        function updateSubmitButton() {
+            const name = nameInput.value.trim();
             const phone = phoneInput.value.trim();
             const phoneRegex = /^01[016789]\d{7,8}$/;
 
-            // 초기화
-            phoneErrorElement.style.display = 'none';
-            phoneInput.classList.remove('invalid');
+            const isFormValid =
+                name.length >= 2 &&
+                phoneRegex.test(phone) &&
+                isDisplayNameChecked &&
+                isDisplayNameValid;
 
-            if (!phoneRegex.test(phone)) {
-                e.preventDefault(); // 폼 제출 막기
-                phoneErrorElement.style.display = 'block';
-                phoneInput.classList.add('invalid');
+            submitBtn.disabled = !isFormValid;
+        }
+
+        // 폼 제출 시 최종 검증
+        form.addEventListener('submit', function(e) {
+            if (!isDisplayNameChecked || !isDisplayNameValid) {
+                e.preventDefault();
+                displayNameMessage.textContent = '닉네임 중복 확인을 완료해주세요.';
+                displayNameMessage.className = 'message error';
             }
         });
-    });
-</script>
 
+        // 페이지 로드 시 초기 검증 수행
+        if (nameInput.value.trim()) {
+            nameInput.dispatchEvent(new Event('input'));
+        }
+        if (displayNameInput.value.trim()) {
+            displayNameInput.dispatchEvent(new Event('input'));
+        }
+        if (phoneInput.value.trim()) {
+            phoneInput.dispatchEvent(new Event('input'));
+        }
+
+        // 초기 상태 설정
+        updateSubmitButton();
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## 📜 PR 내용 요약

*   로컬 및 소셜 로그인/가입 시 사용자의 닉네임(`displayName`)을 자동으로 생성하는 기능을 구현했습니다.
*   이메일 인증 메일의 HTML 구조 및 발신 정보를 개선했습니다.
*   사용자 프로필 수정 기능을 완성하고, 닉네임 중복 검사 기능을 추가했습니다.
*   사용자 엔티티에 이름(`name`) 필드를 추가하고 닉네임(`displayName`)과 분리했습니다.

## ⚒️ 작업 및 변경 내용(상세하게)

### 1. 로그인/가입 시 자동 닉네임 생성 기능 구현

*   **`DisplayNameGenerator` 유틸리티 클래스 추가:**
    *   "형용사 + 동물 + 3자리 숫자" 형태의 유니크한 닉네임을 생성하는 로직을 구현했습니다.
    *   생성된 닉네임이 이미 사용 중인지 `UsersRepository.existsByDisplayName` 메서드를 통해 확인하고, 중복 시 최대 50회까지 재시도합니다.
    *   재시도 후에도 유니크한 닉네임을 생성하지 못할 경우를 대비하여 UUID 기반의 폴백(fallback) 닉네임 생성 로직을 추가했습니다.
*   **로컬 로그인/가입 플로우 수정:**
    *   로컬 회원 가입 시 사용자가 입력하는 필드를 `username`, `password`, `name`, `phone`으로 변경했습니다 (`JoinDTO`에서 `displayName` 필드를 제거하고 `name` 필드를 추가).
    *   `JoinService.joinProcess` 메서드에서 `DisplayNameGenerator`를 주입받아 사용자의 `displayName`을 자동으로 생성하여 저장하도록 로직을 추가했습니다. 사용자가 입력한 `name`과 `phone`도 함께 저장합니다.
*   **소셜 로그인/가입 플로우 수정:**
    *   `CustomOAuth2UserService`에 `DisplayNameGenerator`를 주입받도록 수정했습니다.
    *   `saveOrUpdate` 메서드에서 소셜 로그인 성공 시 `DisplayNameGenerator`를 사용하여 사용자의 `displayName`을 자동으로 생성하여 저장하도록 로직을 추가했습니다.
    *   제공자로부터 받은 사용자 정보(name, nickname, login 등)는 사용자의 `name` 필드에 설정하도록 변경했습니다. 기존에는 이 정보가 `displayName`으로 설정되었습니다.
*   **`Users` 엔티티 및 `UsersRepository` 수정:**
    *   `Users` 엔티티에 사용자의 실제 이름 또는 소셜 제공자 이름에 해당하는 `name` 필드를 추가했습니다.
    *   기존의 `displayName` 필드는 닉네임으로 사용되며, `unique = true` 속성을 추가하여 중복을 허용하지 않도록 변경했습니다.
    *   `UsersRepository`에 `Boolean existsByDisplayName(String displayName);` 메서드를 추가했습니다.

### 2. 이메일 인증 메일 구조 개선

*   **`EmailService.sendEmail` 메서드 수정:**
    *   이메일 발신자 정보를 `krpetty54@gmail.com`과 함께 "Petty Team"이라는 표시 이름을 사용하여 설정하도록 변경했습니다.
    *   이메일 제목을 "[Petty] 이메일 인증 코드입니다."에서 "Petty 인증 코드"로 변경했습니다.
    *   HTML 본문의 구조와 내용을 더 명확하고 보기 좋게 개선했습니다. 인증 코드 유효 시간 및 발신 전용 정보 등을 추가했습니다.
    *   `sendVerificationCode` 메서드에서 이메일 전송 실패 시 `MessagingException` 뿐만 아니라 `UnsupportedEncodingException`도 함께 처리하도록 예외 처리를 보강했습니다.

### 3. 프로필 수정 기능 완성

*   **프로필 정보 조회 및 수정 백엔드 구현:**
    *   `UserProfileEditDTO`에 `name` 필드를 추가하고 `displayName` 필드를 닉네임으로 명시하도록 수정했습니다.
    *   `UserService`에 사용자 ID(UUID)로 프로필 정보 (`name`, `displayName`, `phone`)를 조회하는 `getUserById` 메서드를 추가했습니다.
    *   `UserService`에 프로필 정보 (`name`, `displayName`, `phone`)를 받아 사용자 엔티티를 업데이트하는 `updateUserProfile` 메서드를 추가했습니다.
    *   `updateUserProfile` 메서드 내에서 수정하려는 닉네임(`newDisplayName`)이 현재 사용자의 닉네임과 다를 경우에만 `usersRepository.existsByDisplayName`를 호출하여 중복 검사를 수행하고, 중복 시 예외를 발생시키도록 로직을 추가했습니다.
*   **닉네임 중복 검사 API 구현:**
    *   `UserService`에 특정 닉네임의 사용 가능 여부를 확인하는 `checkDisplayName` 메서드를 추가했습니다. 이 메서드는 해당 닉네임이 이미 존재하는지 확인하되, 현재 사용자의 닉네임인 경우는 사용 가능한 것으로 처리하는 `isCurrentUserDisplayName` 헬퍼 메서드를 활용합니다. 결과는 `available` 상태와 메시지를 담은 Map 형태로 반환합니다.
    *   `UsersApiController`에 `/api/users/check-displayname` GET 엔드포인트를 추가하여 클라이언트에서 닉네임 중복 검사를 요청할 수 있도록 했습니다. 이 API는 인증된 사용자만 호출할 수 있습니다.
*   **프로필 수정 프론트엔드 및 컨트롤러 연동:**
    *   `UsersController`의 `/profile/edit` GET 엔드포인트에서 인증 상태를 확인하고, `userService.getUserById`를 통해 현재 사용자의 프로필 정보를 불러와 `userProfile` 모델 속성으로 `profile_edit.html` 뷰에 전달하도록 수정했습니다. 프로필 정보를 가져오는 중 오류 발생 시 예외를 처리합니다.
    *   `UsersController`의 `/profile/update` POST 엔드포인트에서 `@ModelAttribute`로 받은 `UserProfileEditDTO` 객체를 `userService.updateUserProfile` 메서드에 전달하여 프로필 업데이트를 수행하도록 수정했습니다.
    *   프로필 업데이트 성공 시 성공 메시지를, 실패 시 에러 메시지를 `RedirectAttributes`에 담아 메인 페이지 또는 프로필 수정 페이지로 리다이렉트하도록 했습니다. 실패 시 입력값을 유지하기 위해 `userProfileEditDTO`를 플래시 속성으로 추가했습니다.
    *   `profile_edit.html` 뷰에 이름, 닉네임, 전화번호 입력 필드와 저장 버튼을 구현하고 디자인을 개선했습니다.
    *   닉네임 입력 필드 변경 시 `/api/users/check-displayname` API를 호출하여 닉네임 중복 여부를 실시간으로 확인하고 사용자에게 피드백을 제공하는 클라이언트 측 JavaScript 로직을 추가했습니다. 페이지 로드 시 초기 유효성 검사를 수행합니다.

## 📚 기타 참고 사항

*   사용자의 고유한 식별 값인 닉네임(`displayName`)과 사용자의 실제 이름 또는 제공자 이름인 `name` 필드가 목적에 맞게 분리되어 사용됩니다.
*   자동 생성되는 닉네임은 "형용사 + 동물 + 3자리 숫자" 패턴을 따르며, 중복 시 재시도 메커니즘을 통해 유니크함을 보장합니다.
*   프로필 수정 시 닉네임 변경은 현재 사용자의 기존 닉네임을 제외하고 중복 검사를 수행합니다.