### PR TITLE
[VISION] Vision 분석 페이지 인증 fetch 함수 누락 및 JS 로그인 체크 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,14 +62,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	// ✅ Google Cloud Vision
-	implementation 'com.google.cloud:google-cloud-vision:3.33.0'
-	// ✅ AWS SDK v2 - Rekognition
+	//  AWS SDK v2 - Rekognition
 	implementation platform('software.amazon.awssdk:bom:2.25.19')
 	implementation 'software.amazon.awssdk:rekognition'
-	// ✅ SMTP
+	//  SMTP
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
-	// ✅ Oauth2
+	//  Oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
 	// SpringAI API

--- a/src/main/java/io/github/petty/config/SecurityConfig.java
+++ b/src/main/java/io/github/petty/config/SecurityConfig.java
@@ -67,6 +67,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .requestMatchers("/user").authenticated()
+                        .requestMatchers("/vision/**").authenticated()
+                        .requestMatchers("/flow/**").authenticated()
                         .requestMatchers("/login/**", "/oauth2/**", "/api/auth/refresh").permitAll()
                         .anyRequest().permitAll())
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/io/github/petty/vision/adapter/in/VisionController.java
+++ b/src/main/java/io/github/petty/vision/adapter/in/VisionController.java
@@ -4,9 +4,14 @@ import io.github.petty.vision.helper.ImageValidator;
 import io.github.petty.vision.helper.ImageValidator.ValidationResult;
 import io.github.petty.vision.port.in.VisionUseCase;
 import io.github.petty.vision.service.VisionServiceImpl;
+import io.github.petty.users.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
@@ -14,6 +19,9 @@ import org.springframework.http.HttpStatus;
 
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Controller
@@ -23,9 +31,34 @@ public class VisionController {
     private final VisionUseCase vision;
     private final VisionServiceImpl visionService;
     private final ImageValidator imageValidator;
+    private final UserService userService;
+
+    // 일일 사용량 제한 (설정값으로 쉽게 변경 가능)
+    private static final int DAILY_LIMIT = 3;
+
+    // 세션 키 상수
+    private static final String SESSION_USAGE_COUNT = "vision_daily_usage_count";
+    private static final String SESSION_USAGE_DATE = "vision_usage_date";
 
     @GetMapping("/upload")
-    public String page() {
+    public String page(Model model, HttpSession session) {  // <-- 반드시 HttpSession 파라미터 추가
+        // 로그인 확인
+        if (!isAuthenticated()) {
+            return "redirect:/login";
+        }
+
+        // 현재 사용자의 사용량 정보를 모델에 추가
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        int remainingUsage = getRemainingUsage(session);  // 세션 파라미터 전달
+
+        model.addAttribute("remainingUsage", remainingUsage);
+        model.addAttribute("canUse", remainingUsage > 0);
+        model.addAttribute("dailyLimit", DAILY_LIMIT);
+        model.addAttribute("username", auth.getName());
+
+        log.info("📊 Vision 페이지 접근: 사용자={}, 남은횟수={}/{}",
+                auth.getName(), remainingUsage, DAILY_LIMIT);
+
         return "visionUpload";
     }
 
@@ -36,29 +69,28 @@ public class VisionController {
             @RequestParam("petName") String petName,
             HttpSession session
     ) throws IOException {
-        // 파일 유효성 검사
+        if (!isAuthenticated()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
         ValidationResult vr = imageValidator.validate(file);
         if (!vr.isValid()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, vr.getMessage());
         }
-
-        // UnifiedFlowController와 호환되도록 세션에 데이터 저장
-        session.setAttribute("petName", petName);
-
-        // 파일을 임시로 저장 (나중에 analyze에서 사용)
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         try {
+            session.setAttribute("petName", petName);
             byte[] imageBytes = file.getBytes();
             session.setAttribute("tempImageBytes", imageBytes);
-
-            // 이미지를 Base64로 인코딩하여 세션에 저장
             String imageBase64 = java.util.Base64.getEncoder().encodeToString(imageBytes);
             session.setAttribute("petImageBase64", "data:image/jpeg;base64," + imageBase64);
-        } catch (IOException e) {
-            log.warn("이미지 저장 실패", e);
+            String result = vision.interim(file.getBytes(), petName);
+            log.info("🔍 종 분석 성공: 사용자={}, 반려동물={}", auth.getName(), petName);
+            return result;
+        } catch (Exception e) {
+            log.error("❌ 종 분석 실패: 사용자={}, 오류={}", auth.getName(), e.getMessage());
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "분석 중 오류가 발생했습니다: " + e.getMessage());
         }
-
-        // 기존 서비스 호출
-        return vision.interim(file.getBytes(), petName);
     }
 
     @PostMapping("/analyze")
@@ -68,27 +100,86 @@ public class VisionController {
             @RequestParam("petName") String petName,
             HttpSession session
     ) {
-        // 파일 유효성 검사
+        if (!isAuthenticated()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!canAnalyzeToday(session)) {
+            int todayUsage = getTodayUsage(session);
+            String errorMessage = String.format(
+                    "오늘의 분석 한도(%d회)를 모두 사용하셨습니다. (사용: %d회)\n" +
+                            "내일 다시 이용해주세요! 🐾", DAILY_LIMIT, todayUsage);
+            log.warn("⚠️ 사용량 한도 초과: 사용자={}, 사용횟수={}/{}",
+                    auth.getName(), todayUsage, DAILY_LIMIT);
+            throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, errorMessage);
+        }
         ValidationResult vr = imageValidator.validate(file);
         if (!vr.isValid()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, vr.getMessage());
         }
-
         try {
-            // Vision 분석 결과 생성
             String visionReport = visionService.analyze(file, petName);
-
-            // UnifiedFlowController와 호환되도록 세션에 결과 저장
+            incrementUsage(session);
             session.setAttribute("visionReport", visionReport);
             session.setAttribute("petName", petName);
-
-            log.info("✅ Vision 분석 완료 - petName: {}, reportLength: {}",
-                    petName, visionReport != null ? visionReport.length() : 0);
-
+            log.info("✅ Vision 분석 완료: 사용자={}, 반려동물={}, 남은횟수={}/{}",
+                    auth.getName(), petName, getRemainingUsage(session), DAILY_LIMIT);
             return visionReport;
         } catch (Exception e) {
-            log.error("❌ Vision 분석 실패", e);
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "분석 중 오류가 발생했습니다: " + e.getMessage());
+            log.error("❌ Vision 분석 실패: 사용자={}, 오류={}", auth.getName(), e.getMessage());
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "분석 중 오류가 발생했습니다: " + e.getMessage());
         }
+    }
+
+    @GetMapping("/usage")
+    @ResponseBody
+    public Map<String, Object> getUserUsage(HttpSession session) {
+        if (!isAuthenticated()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        }
+        Map<String, Object> response = new HashMap<>();
+        response.put("remainingUsage", getRemainingUsage(session));
+        response.put("todayUsage", getTodayUsage(session));
+        response.put("dailyLimit", DAILY_LIMIT);
+        return response;
+    }
+
+    // =============== 헬퍼 메서드들 ===============
+
+    private boolean isAuthenticated() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth != null && auth.isAuthenticated() &&
+                !(auth instanceof AnonymousAuthenticationToken);
+    }
+
+    private boolean canAnalyzeToday(HttpSession session) {
+        int todayUsage = getTodayUsage(session);
+        return todayUsage < DAILY_LIMIT;
+    }
+
+    private int getTodayUsage(HttpSession session) {
+        String today = LocalDate.now().toString();
+        String sessionDate = (String) session.getAttribute(SESSION_USAGE_DATE);
+        if (!today.equals(sessionDate)) {
+            session.setAttribute(SESSION_USAGE_DATE, today);
+            session.setAttribute(SESSION_USAGE_COUNT, 0);
+            return 0;
+        }
+        Integer count = (Integer) session.getAttribute(SESSION_USAGE_COUNT);
+        return count != null ? count : 0;
+    }
+
+    private int getRemainingUsage(HttpSession session) {
+        int todayUsage = getTodayUsage(session);
+        return Math.max(0, DAILY_LIMIT - todayUsage);
+    }
+
+    private void incrementUsage(HttpSession session) {
+        int currentUsage = getTodayUsage(session);
+        session.setAttribute(SESSION_USAGE_COUNT, currentUsage + 1);
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        log.info("📈 사용량 증가: 사용자={}, 새로운사용량={}/{}",
+                auth.getName(), currentUsage + 1, DAILY_LIMIT);
     }
 }

--- a/src/main/resources/templates/visionUpload.html
+++ b/src/main/resources/templates/visionUpload.html
@@ -158,6 +158,26 @@
                 margin: 1rem 0;
                 font-weight: 500;
             }
+            /* 비활성화된 폼 스타일 */
+            .disabled {
+                opacity: 0.6;
+                pointer-events: none;
+            }
+
+            /* 사용량 정보 박스 스타일 개선 */
+            .alert-info {
+                background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+                color: white;
+                border: none;
+                border-radius: var(--border-radius-lg);
+            }
+
+            .alert-warning {
+                background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+                color: white;
+                border: none;
+                border-radius: var(--border-radius-lg);
+            }
         </style>
     </th:block>
 </head>
@@ -173,17 +193,42 @@
             <!-- 메인 폼 카드 -->
             <div class="card">
                 <div class="card-body" id="formContainer">
+                    <!-- ✅ 사용량 정보 표시 추가 -->
+                    <div th:if="${username}" class="alert alert-info text-center mb-4">
+                        <strong>🎉 안녕하세요, <span th:text="${username}"></span>님!</strong><br>
+                        <span th:if="${canUse}">
+                오늘 <strong th:text="${remainingUsage}"></strong>회 더 분석하실 수 있습니다.
+                (총 <span th:text="${dailyLimit}"></span>회 중 <span th:text="${dailyLimit - remainingUsage}"></span>회 사용됨)
+            </span>
+                        <span th:unless="${canUse}" class="text-warning">
+                <i class="bi bi-exclamation-triangle"></i>
+                오늘의 분석 한도(<span th:text="${dailyLimit}"></span>회)를 모두 사용하셨습니다.<br>
+                내일 다시 이용해주세요! 🐾
+            </span>
+                    </div>
+
+                    <!-- ✅ 로그인하지 않은 경우 안내 -->
+                    <div th:unless="${username}" class="alert alert-warning text-center mb-4">
+                        <i class="bi bi-lock"></i>
+                        <strong>Vision 분석 기능을 이용하려면 로그인이 필요합니다.</strong><br>
+                        <a href="/login" class="btn btn-primary btn-sm mt-2">로그인하기</a>
+                    </div>
+
                     <h3 class="text-center mb-4">🐾 반려동물 정보를 입력하세요</h3>
-                    <form id="visionForm">
+
+                    <!-- ✅ 사용량 초과 시 폼 비활성화 -->
+                    <form id="visionForm" th:classappend="${!canUse} ? 'disabled' : ''">
                         <div class="mb-3">
                             <label for="petName" class="form-label">반려동물 이름</label>
                             <input type="text" class="form-control" name="petName" id="petName"
-                                   placeholder="반려동물의 이름을 입력하세요" required />
+                                   placeholder="반려동물의 이름을 입력하세요"
+                                   th:disabled="${!canUse}" required />
                         </div>
                         <div class="mb-3">
                             <label for="file" class="form-label">이미지 선택</label>
                             <input type="file" class="form-control" name="file" id="file"
-                                   accept="image/jpeg,image/jpg,image/png" required />
+                                   accept="image/jpeg,image/jpg,image/png"
+                                   th:disabled="${!canUse}" required />
                             <small class="text-muted">⚠️ JPEG, PNG 형식만 지원합니다 (최대 5MB)</small>
                         </div>
                         <!-- 이미지 미리보기 -->
@@ -191,12 +236,15 @@
                             <img id="previewImg" src="" alt="미리보기" class="img-fluid rounded" />
                         </div>
                         <div class="d-grid">
-                            <button type="submit" class="btn btn-primary" id="submitBtn">분석하기</button>
+                            <button type="submit" class="btn btn-primary" id="submitBtn"
+                                    th:disabled="${!canUse}">
+                                <span th:if="${canUse}">분석하기</span>
+                                <span th:unless="${canUse}">사용량 초과</span>
+                            </button>
                         </div>
                     </form>
                 </div>
             </div>
-
             <!-- 로딩 스피너 -->
             <div id="spinnerContainer" class="text-center mt-3" style="display: none">
                 <div class="spinner-border" role="status">
@@ -255,87 +303,26 @@
         const previewImg = document.getElementById('previewImg');
         const errorMessage = document.getElementById('errorMessage');
         const offlineAlert = document.getElementById('offlineAlert');
-
-        // 오프라인 상태 감지
-        function updateOnlineStatus() {
-            offlineAlert.style.display = navigator.onLine ? 'none' : 'block';
-        }
-        window.addEventListener('online', updateOnlineStatus);
-        window.addEventListener('offline', updateOnlineStatus);
-        updateOnlineStatus();
-
-        // 파일 선택 시 미리보기 및 검증
-        fileInput.addEventListener('change', function(e) {
-            const file = e.target.files[0];
-            if (!file) {
-                imagePreview.style.display = 'none';
-                return;
-            }
-
-            // 파일 형식 검증
-            const validTypes = ['image/jpeg', 'image/jpg', 'image/png'];
-            if (!validTypes.includes(file.type)) {
-                alert('AWS Rekognition은 JPEG, PNG 형식만 지원합니다.');
-                fileInput.value = '';
-                imagePreview.style.display = 'none';
-                return;
-            }
-
-            // 파일 크기 검증 (5MB)
-            if (file.size > 5 * 1024 * 1024) {
-                alert('파일 크기는 5MB 이하여야 합니다.');
-                fileInput.value = '';
-                imagePreview.style.display = 'none';
-                return;
-            }
-
-            // 미리보기 표시
-            const reader = new FileReader();
-            reader.onload = function(e) {
-                previewImg.src = e.target.result;
-                imagePreview.style.display = 'block';
-            };
-            reader.readAsDataURL(file);
-        });
-
-        // 인증된 fetch 함수
-        async function authenticatedFetch(url, options = {}) {
-            try {
-                let response = await fetch(url, {
-                    ...options,
-                    credentials: 'include'
-                });
-
-                if (response.status !== 401) {
-                    return response;
-                }
-
-                // 401 응답 시 토큰 갱신 시도
-                console.log('토큰 갱신 시도...');
-                const refreshResponse = await fetch('/api/auth/refresh', {
-                    method: 'POST',
-                    credentials: 'include'
-                });
-
-                if (!refreshResponse.ok) {
-                    window.location.href = '/login';
-                    throw new Error('세션 만료');
-                }
-
-                // 원래 요청 재시도
-                return await fetch(url, {
-                    ...options,
-                    credentials: 'include'
-                });
-
-            } catch (error) {
-                console.error('인증 처리 오류:', error);
-                throw error;
-            }
-        }
+        const isLoggedIn = /*[[${username != null} ? 'true' : 'false']]*/ 'false';
+        const canUse = /*[[${canUse} ? 'true' : 'false']]*/ 'false';
+        const remainingUsage = /*[[${remainingUsage}]]*/ 0;
 
         form.addEventListener('submit', async e => {
             e.preventDefault();
+
+            // 로그인 체크
+            if (isLoggedIn !== 'true') {
+                if (confirm('로그인이 필요한 기능입니다. 로그인 페이지로 이동하시겠습니까?')) {
+                    window.location.href = '/login';
+                }
+                return;
+            }
+
+            // 사용량 체크
+            if (!canUse) {
+                alert('오늘의 분석 한도를 초과했습니다. 내일 다시 이용해주세요!');
+                return;
+            }
 
             // 오프라인 체크
             if (!navigator.onLine) {
@@ -369,6 +356,11 @@
                 });
 
                 if (!res1.ok) {
+                    if (res1.status === 401) {
+                        alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+                        window.location.href = '/login';
+                        return;
+                    }
                     throw new Error('종 분석에 실패했습니다.');
                 }
 
@@ -389,13 +381,24 @@
             }
 
             try {
-                // 두 번째 분석 (OpenAI) - 백그라운드에서 실행
+                // 두 번째 분석 (Vision)
                 const res2 = await authenticatedFetch('/vision/analyze', {
                     method: 'POST',
                     body: fd
                 });
 
                 if (!res2.ok) {
+                    if (res2.status === 401) {
+                        alert('세션이 만료되었습니다. 다시 로그인해주세요.');
+                        window.location.href = '/login';
+                        return;
+                    } else if (res2.status === 429) {
+                        const errorText = await res2.text();
+                        alert(errorText);
+                        // 페이지 새로고침하여 사용량 정보 업데이트
+                        window.location.reload();
+                        return;
+                    }
                     throw new Error('최종 분석에 실패했습니다.');
                 }
 
@@ -422,6 +425,14 @@
                 errorMessage.textContent = '분석 중 오류가 발생했습니다: ' + e.message;
                 errorMessage.style.display = 'block';
                 console.error(e);
+            }
+
+            function authenticatedFetch(url, options) {
+                // 항상 쿠키(JWT 포함)도 함께 보냄
+                return fetch(url, {
+                    ...options,
+                    credentials: 'include'
+                });
             }
         });
     </script>


### PR DESCRIPTION
## 📜 PR 내용 요약
> Vision 분석(동물 이미지 업로드) 페이지에서 인증이 필요한 fetch 요청 시 authenticatedFetch 함수 미정의로 발생하던 오류를 해결하고, 로그인 상태를 올바르게 전달·비교하도록 JS 로직을 개선했습니다. 이를 통해 로그인 유저의 정상적인 분석 기능 사용과 인증 기반 API 요청이 가능해졌습니다.
## ⚒️ 작업 및 변경 내용(상세하게)
![image](https://github.com/user-attachments/assets/8108c37f-cbed-40b1-87e5-306dbeb6685b)
![image](https://github.com/user-attachments/assets/85178356-2cb6-4e4d-8809-e02b47a19262)

- visionUpload.html
  - 인증 fetch 함수(authenticatedFetch) 정의 및 추가→ 모든 fetch 요청에 credentials: 'include' 적용, JWT 쿠키 항상 포함
   - 기존 JS의 로그인 상태 전달 방식을
     - ${isLoggedIn} 등 Boolean 값을 'true'/'false' 문자열로 바인딩하도록 개선
     - JS에서 isLoggedIn !== 'true' 식으로 비교, 실질적인 인증 유저만 분석 가능하도록 수정
  - UI submit 이벤트 및 인증 오류 팝업 정상 동작
- 버그 재현/수정 사항
  - authenticatedFetch 함수 미정의(ReferenceError)로 인한 이미지 분석 불가 문제 해결
  - 로그인 유저임에도 JS에서 항상 비로그인으로 인식되는 오류 해결

## 📚 기타 참고 사항

- 만약 여러 페이지에서 인증 fetch가 필요하다면 별도의 공통 JS 파일로 분리할 수 있습니다.
- 추후 사용자 인증/권한 관리가 추가될 경우, 이 패턴으로 확장/재사용 가능
- QA 체크포인트: 로그인 상태에서 분석이 정상 동작하는지, 비로그인/사용량 초과 시 안내 팝업이 잘 동작하는지 반드시 확인 요망