### PR TITLE
[USER] 유저 정보 API 개선 및 에러 페이지 추가, 권한 정책 반영

### DIFF
--- a/src/main/java/io/github/petty/users/controller/UsersApiController.java
+++ b/src/main/java/io/github/petty/users/controller/UsersApiController.java
@@ -3,7 +3,9 @@ package io.github.petty.users.controller;
 import io.github.petty.users.dto.EmailVerificationRequest;
 import io.github.petty.users.dto.RefreshTokenResponseDTO;
 import io.github.petty.users.dto.VerifyCodeRequest;
+import io.github.petty.users.entity.Users;
 import io.github.petty.users.jwt.JWTUtil;
+import io.github.petty.users.repository.UsersRepository;
 import io.github.petty.users.service.EmailService;
 import io.github.petty.users.service.RefreshTokenService;
 import io.github.petty.users.service.UserService;
@@ -29,13 +31,15 @@ public class UsersApiController {
     private final EmailService emailService;
     private final RefreshTokenService refreshTokenService;
     private final CookieUtils cookieUtils;
+    private final UsersRepository usersRepository;
 
-    public UsersApiController(JWTUtil jwtUtil, EmailService emailService, RefreshTokenService refreshTokenService, UserService userService, CookieUtils cookieUtils) {
+    public UsersApiController(JWTUtil jwtUtil, EmailService emailService, RefreshTokenService refreshTokenService, UserService userService, CookieUtils cookieUtils, UsersRepository usersRepository) {
         this.jwtUtil = jwtUtil;
         this.userService = userService;
         this.emailService = emailService;
         this.refreshTokenService = refreshTokenService;
         this.cookieUtils = cookieUtils;
+        this.usersRepository = usersRepository;
     }
 
     @GetMapping("/users/me")
@@ -46,8 +50,11 @@ public class UsersApiController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
+        Users user = usersRepository.findByUsername(auth.getName());
+
         Map<String, String> userInfo = new HashMap<>();
-        userInfo.put("username", auth.getName());
+        // TODO: 프론트엔드에서 username 키로 displayName을 사용 중(키 이름 정리 필요)
+        userInfo.put("username", user.getDisplayName());
         userInfo.put("role", auth.getAuthorities().iterator().next().getAuthority());
 
         return ResponseEntity.ok(userInfo);

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/defaultLayout}">
+<head>
+    <title>페이지를 찾을 수 없습니다</title>
+    <th:block layout:fragment="css">
+        <style>
+            .error-container {
+                text-align: center;
+                padding: 50px 20px;
+                max-width: 600px;
+                margin: 0 auto;
+            }
+
+            .error-code {
+                font-size: 8rem;
+                font-weight: bold;
+                margin: 0;
+                background: linear-gradient(45deg, var(--accent-color), var(--point-color));
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;
+                background-clip: text;
+                text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+            }
+
+            .error-title {
+                font-size: 2rem;
+                color: var(--text-color);
+                margin: 20px 0;
+                font-weight: 600;
+            }
+
+            .error-message {
+                font-size: 1.2rem;
+                color: var(--secondary-text-color);
+                margin-bottom: 30px;
+                line-height: 1.6;
+            }
+
+            .error-actions {
+                display: flex;
+                gap: 15px;
+                justify-content: center;
+                flex-wrap: wrap;
+                margin-top: 40px;
+            }
+
+            .btn {
+                padding: 12px 24px;
+                border-radius: 30px;
+                font-size: 1rem;
+                font-weight: 600;
+                text-decoration: none;
+                transition: all 0.3s ease;
+                cursor: pointer;
+                border: none;
+                font-family: inherit;
+                display: inline-block;
+            }
+
+            .btn-primary {
+                background-color: var(--accent-color);
+                color: white;
+            }
+
+            .btn-primary:hover {
+                background-color: var(--button-hover-color);
+                transform: translateY(-2px);
+                box-shadow: var(--box-shadow-cute);
+            }
+
+            .btn-secondary {
+                background-color: var(--point-color);
+                color: white;
+            }
+
+            .btn-secondary:hover {
+                background-color: #8fa97a;
+                transform: translateY(-2px);
+            }
+
+            .cute-illustration {
+                font-size: 4rem;
+                margin: 30px 0;
+                opacity: 0.8;
+            }
+
+            .search-suggestion {
+                background-color: var(--card-bg-color);
+                border-radius: var(--border-radius-lg);
+                padding: 25px;
+                margin: 30px 0;
+                box-shadow: var(--box-shadow-light);
+            }
+
+            .search-suggestion h3 {
+                color: var(--accent-color);
+                margin-bottom: 15px;
+                font-size: 1.3rem;
+            }
+
+            .quick-links {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                gap: 15px;
+                margin-top: 20px;
+            }
+
+            .quick-link {
+                display: block;
+                padding: 15px;
+                background-color: rgba(158, 188, 138, 0.1);
+                border-radius: var(--border-radius-md);
+                text-decoration: none;
+                color: var(--text-color);
+                transition: all 0.3s ease;
+                border: 2px solid transparent;
+            }
+
+            .quick-link:hover {
+                background-color: var(--point-color);
+                color: white;
+                transform: translateY(-2px);
+                border-color: var(--accent-color);
+            }
+
+            .quick-link .icon {
+                font-size: 1.5rem;
+                margin-bottom: 8px;
+                display: block;
+            }
+
+            .quick-link .title {
+                font-weight: 600;
+                margin-bottom: 5px;
+            }
+
+            .quick-link .desc {
+                font-size: 0.9rem;
+                opacity: 0.8;
+            }
+
+            @media (max-width: 768px) {
+                .error-code {
+                    font-size: 6rem;
+                }
+
+                .error-title {
+                    font-size: 1.5rem;
+                }
+
+                .error-message {
+                    font-size: 1rem;
+                }
+
+                .error-actions {
+                    flex-direction: column;
+                    align-items: center;
+                }
+
+                .btn {
+                    width: 100%;
+                    max-width: 250px;
+                }
+            }
+        </style>
+    </th:block>
+</head>
+<body>
+<th:block layout:fragment="content">
+    <main>
+        <div class="error-container">
+            <div class="error-code">404</div>
+            <h1 class="error-title">페이지를 찾을 수 없습니다</h1>
+            <div class="cute-illustration">🐕‍🦺 🔍</div>
+            <p class="error-message">
+                앗! 우리 반려동물이 길을 잃었나봐요.<br>
+                요청하신 페이지를 찾을 수 없습니다.
+            </p>
+        </div>
+    </main>
+</th:block>
+
+<th:block layout:fragment="script">
+    <script>
+        // 페이지 로드 시 귀여운 애니메이션 효과
+        document.addEventListener('DOMContentLoaded', function() {
+            const illustration = document.querySelector('.cute-illustration');
+            if (illustration) {
+                illustration.style.opacity = '0';
+                illustration.style.transform = 'scale(0.8)';
+
+                setTimeout(() => {
+                    illustration.style.transition = 'all 0.5s ease';
+                    illustration.style.opacity = '0.8';
+                    illustration.style.transform = 'scale(1)';
+                }, 200);
+            }
+        });
+    </script>
+</th:block>
+</body>
+</html>


### PR DESCRIPTION
## 📜 PR 내용 요약

*   `/users/me` API에서 사용자 **`displayName`을 반환하도록 개선**했습니다.
*   다양한 엔드포인트에 대한 **권한 정책을 세분화하여 보안을 강화**하고, API 요청에 대한 인증 오류 응답을 표준화했습니다.
*   **404 에러 페이지를 추가**하여 사용자 경험을 개선했습니다.

## ⚒️ 작업 및 변경 내용(상세하게)

### 1. `/users/me` API 개선
*   **`UsersApiController`의 `getUserInfo()` 메서드에서 `/users/me` 엔드포인트 요청 시, 기존에 `username`으로 반환되던 값을 사용자의 `displayName`으로 변경하여 반환하도록 수정**했습니다.
*   이는 프론트엔드에서 `username` 키를 `displayName`으로 사용하는 현재 상황을 반영하기 위함입니다.
*   이 변경을 위해 `UsersApiController`의 생성자에 `UsersRepository`를 주입받아 사용자의 `displayName`을 조회하도록 로직을 개선했습니다.

### 2. 권한 정책 강화 및 인증 오류 응답 개선
*   `src/main/java/io/github/petty/config/SecurityConfig.java` 파일에서 **다양한 API 및 웹 페이지에 대한 접근 권한을 세분화**했습니다.
*   **관리자(`ADMIN`) 역할이 필요한 경로를 명확히 정의**했습니다:
    *   `/admin/**`
    *   `/api/posts/update-counts`
    *   `/manual-sync/**`, `/embedding-batch/**`
*   **인증된 사용자(`authenticated`)만 접근 가능한 경로를 추가 및 수정**했습니다:
    *   `/profile/**`
    *   `/posts/detail`, `/posts/*/new`, `/posts/*/edit`
    *   `POST` 요청 시 `/api/posts`
    *   `PUT` 요청 시 `/api/posts/**`
    *   `DELETE` 요청 시 `/api/posts/**`
    *   `POST` 요청 시 `/api/posts/{id}/comments`
    *   `PUT` 요청 시 `/api/comments/**`
    *   `DELETE` 요청 시 `/api/comments/**`
    *   `POST` 요청 시 `/api/posts/{id}/like`
    *   `/api/images/**`
    *   `/api/users/me`, `/api/check-displayname`
    *   기존의 `/flow/**` 경로도 인증이 필요하도록 유지했습니다.
*   **인증 예외 처리(`authenticationEntryPoint`)를 개선**했습니다:
    *   `/api/`로 시작하는 API 요청에 대해 인증이 필요할 경우, **`401 Unauthorized` 상태 코드와 함께 JSON 형식의 오류 메시지 (`{"error": "로그인이 필요합니다"}`)를 반환**하도록 수정했습니다.
    *   그 외 웹 페이지 요청에 대해서는 `/login` 페이지로 리다이렉트하도록 처리했습니다.

### 3. 404 에러 페이지 추가
*   `src/main/resources/templates/error/404.html` 경로에 **새로운 404 에러 페이지를 추가**했습니다.
*   해당 페이지는 "페이지를 찾을 수 없습니다"라는 메시지와 함께 사용자에게 친근한 안내를 제공합니다.

## 📚 기타 참고 사항
* 궁금한 점이 있으시면 언제든지 물어봐 주세요.
