### PR TITLE
[COMMUNITY] 게시글 수정, 삭제 안되는 문제 해결

### DIFF
--- a/src/main/java/io/github/petty/community/controller/PostController.java
+++ b/src/main/java/io/github/petty/community/controller/PostController.java
@@ -97,17 +97,4 @@ public class PostController {
             return ResponseEntity.status(500).body("좋아요 처리에 실패했습니다.");
         }
     }
-    
-    // 🔥 기존 데이터 업데이트를 위한 임시 엔드포인트 (관리자용)
-    @PostMapping("/update-counts")
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<?> updateAllPostCounts(@AuthenticationPrincipal CustomUserDetails userDetails) {
-            // 관리자 권한 확인
-            if (!userDetails.getAuthorities().stream()
-                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
-                return ResponseEntity.status(403).body("관리자 권한이 필요합니다.");
-                }
-        postService.updateAllPostCounts();
-        return ResponseEntity.ok(Map.of("message", "모든 게시글의 댓글 수와 좋아요 수가 업데이트되었습니다."));
-    }
 }

--- a/src/main/resources/static/js/common/edit-qna.js
+++ b/src/main/resources/static/js/common/edit-qna.js
@@ -188,7 +188,7 @@ async function checkPostOwnership() {
         }
 
         // 🔐 작성자 본인이 아니면 접근 차단
-        const isOwner = currentUser.username === post.userName;
+        const isOwner = currentUser.username === post.writer;
         if (!isOwner) {
             alert("본인이 작성한 게시글만 수정할 수 있습니다.");
             window.location.replace(`/posts/detail?id=${postId}`);

--- a/src/main/resources/static/js/common/edit-review.js
+++ b/src/main/resources/static/js/common/edit-review.js
@@ -190,7 +190,7 @@ async function checkPostOwnership() {
         }
 
         // 🔐 작성자 본인이 아니면 접근 차단
-        const isOwner = currentUser.username === post.userName;
+        const isOwner = currentUser.username === post.writer;
         if (!isOwner) {
             alert("본인이 작성한 게시글만 수정할 수 있습니다.");
             window.location.replace(`/posts/detail?id=${postId}`);

--- a/src/main/resources/static/js/common/edit-showoff.js
+++ b/src/main/resources/static/js/common/edit-showoff.js
@@ -176,7 +176,7 @@ async function checkPostOwnership() {
         }
 
         // 🔐 작성자 본인이 아니면 접근 차단
-        const isOwner = currentUser.username === post.userName;
+        const isOwner = currentUser.username === post.writer;
         if (!isOwner) {
             alert("본인이 작성한 게시글만 수정할 수 있습니다.");
             window.location.replace(`/posts/detail?id=${postId}`);

--- a/src/main/resources/templates/post-detail.html
+++ b/src/main/resources/templates/post-detail.html
@@ -728,10 +728,6 @@
                 </div>
 
                 <div class="post-content">
-                    <div class="post-images">
-                        <!-- 이미지가 AJAX로 로드됩니다 -->
-                        <img src="/api/placeholder/400/320" alt="placeholder" class="loading-placeholder">
-                    </div>
 
                     <p>게시글 내용을 불러오는 중입니다... 잠시만 기다려 주세요! 🐕‍🦺</p>
 

--- a/src/main/resources/templates/post-detail.html
+++ b/src/main/resources/templates/post-detail.html
@@ -837,7 +837,7 @@
             const currentUser = await getCurrentUser();
             const loggedIn = !!currentUser;  // getCurrentUser 결과로 로그인 상태 판단
 
-            const isOwner = currentUser && (currentUser.username === post.userName);
+            const isOwner = currentUser && (currentUser.username === post.writer);
             const container = document.getElementById("postDetail");
 
             let petTypeLabel = '';
@@ -1159,8 +1159,7 @@
                 div.className = "comment";
 
                 // 🔐 댓글 작성자 본인인지 확인
-                const isCommentOwner = currentUser &&
-                    (currentUser.username === comment.userName);
+                const isCommentOwner = currentUser && (currentUser.username === comment.writer);
 
                 // 🔐 댓글 작성자에게만 수정/삭제 버튼 표시
                 const commentActionsHtml = isCommentOwner ? `


### PR DESCRIPTION
# 🚀 Pull Request

## 📜 PR 내용 요약
**필드명 불일치 문제 해결 및 불필요한 관리자 엔드포인트 제거**

사용자 인증 관련 필드명이 변경되면서 발생한 게시글/댓글 작성자 확인 로직 오류를 수정하고, 더 이상 사용하지 않는 관리자용 임시 엔드포인트를 정리했습니다.

## ⚒️ 작업 및 변경 내용(상세하게)

### 🔧 필드명 수정
- **게시글 작성자 확인 로직 수정**
  - `post.userName` → `post.writer`로 변경
  - 영향 파일: `post-detail.html`, `edit-qna.js`, `edit-review.js`, `edit-showoff.js`

- **댓글 작성자 확인 로직 수정**
  - `comment.userName` → `comment.writer`로 변경
  - 영향 파일: `post-detail.html`

### 🗑️ 코드 정리
- **불필요한 관리자 엔드포인트 제거**
  - `PostController.java`에서 `updateAllPostCounts()` 메서드 삭제
  - `@PostMapping("/update-counts")` 엔드포인트 제거
  - 13줄의 임시 코드 정리

### 🐛 해결된 버그
- 게시글 작성자 본인에게 수정/삭제 버튼이 표시되지 않던 문제
- 댓글 작성자 본인에게 수정/삭제 버튼이 표시되지 않던 문제
- 작성자가 아닌 사용자도 수정 페이지에 접근할 수 있던 보안 문제

## 📚 기타 참고 사항

### 🔍 리뷰 포인트
1. **보안**: 작성자 확인 로직이 올바르게 수정되었는지 확인
2. **일관성**: 모든 파일에서 동일한 필드명(`writer`)을 사용하는지 확인
3. **테스트**: 게시글/댓글의 수정/삭제 권한이 올바르게 작동하는지 테스트 필요

### 🧪 테스트 방법
```javascript
// 콘솔에서 작성자 확인 테스트
getCurrentUser().then(currentUser => {
    fetch(`/api/posts/${postId}`).then(res => res.json()).then(post => {
        console.log('현재 사용자:', currentUser.username);
        console.log('게시글 작성자:', post.writer);
        console.log('작성자 일치:', currentUser.username === post.writer);
    });
});
```